### PR TITLE
Preserve activity names

### DIFF
--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyPlan.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyPlan.java
@@ -94,7 +94,7 @@ public final class ReadonlyPlan implements Plan {
 
                                  return new Directive<A>(
                                      deserializer.invoke(SerializedValue.of(dir.serializedActivity().getArguments())),
-                                     dir.serializedActivity().getTypeName() + " " + dirId.id(),
+                                     dir.name(),
                                      dirId,
                                      dir.serializedActivity().getTypeName(),
                                      dirStart

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityDirectiveRecord.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/ActivityDirectiveRecord.java
@@ -10,5 +10,6 @@ public record ActivityDirectiveRecord(
     long startOffsetInMicros,
     Map<String, SerializedValue> arguments,
     Integer anchorId, // anchorId can be null (representing Plan)
-    boolean anchoredToStart
+    boolean anchoredToStart,
+    String name
 ) {}

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityDirectivesAction.java
@@ -19,7 +19,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
       ceil(extract(epoch from a.start_offset) * 1000*1000) as start_offset_in_micros,
       a.arguments,
       a.anchor_id,
-      a.anchored_to_start
+      a.anchored_to_start,
+      a.name
     from merlin.activity_directive as a
     where a.plan_id = ?
     """;
@@ -44,7 +45,8 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
                 getJsonColumn(results, "arguments", activityArgumentsP)
                     .getSuccessOrThrow($ -> new Error("Corrupt activity arguments cannot be parsed: " + $.reason())),
                 (Integer)results.getObject("anchor_id"),
-                results.getBoolean("anchored_to_start"))
+                results.getBoolean("anchored_to_start"),
+                (String)results.getObject("name"))
         );
       }
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityDirectivesAction.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetActivityDirectivesAction.java
@@ -46,7 +46,7 @@ import static gov.nasa.jpl.aerie.merlin.server.remotes.postgres.PostgresParsers.
                     .getSuccessOrThrow($ -> new Error("Corrupt activity arguments cannot be parsed: " + $.reason())),
                 (Integer)results.getObject("anchor_id"),
                 results.getBoolean("anchored_to_start"),
-                (String)results.getObject("name"))
+                results.getString("name"))
         );
       }
     }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -315,8 +315,9 @@ public final class PostgresPlanRepository implements PlanRepository {
                   Duration.of(a.startOffsetInMicros(), Duration.MICROSECONDS),
                   a.type(),
                   a.arguments(),
-                  a.anchorId()!=null? new ActivityDirectiveId(a.anchorId()): null,
-                  a.anchoredToStart())));
+                  a.anchorId()!=null ? new ActivityDirectiveId(a.anchorId()) : null,
+                  a.anchoredToStart(),
+                  a.name())));
     }
   }
 

--- a/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/PlanJsonParser.java
+++ b/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/PlanJsonParser.java
@@ -72,6 +72,7 @@ public class PlanJsonParser {
       final var anchoredToStart = a.getBoolean("anchored_to_start");
       final var anchorId = a.isNull("anchor_id") ? null : new ActivityDirectiveId(a.getInt("anchor_id"));
       final var arguments = activityArgumentsP.parse(a.getJsonObject("arguments")).getSuccessOrThrow();
+      final var name = a.get("name") == null || a.isNull("name") ? null : a.getString("name");
 
       activitiesMap.put(
           id,
@@ -80,7 +81,8 @@ public class PlanJsonParser {
               type,
               arguments,
               anchorId,
-              anchoredToStart
+              anchoredToStart,
+              name
           ));
     });
 

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/NewDirective.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/NewDirective.kt
@@ -11,7 +11,7 @@ data class NewDirective(
     val inner: AnyDirective,
 
     /** The name of the activity. */
-    val name: String,
+    val name: String?,
 
     /** The activity type. */
     val type: String,

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
@@ -135,7 +135,8 @@ public class TypeUtilsEditablePlanAdapter implements gov.nasa.ammos.aerie.proced
               case DirectiveStart.Anchor a -> a.getAnchorPoint() == DirectiveStart.Anchor.AnchorPoint.Start;
               case DirectiveStart.Absolute a -> true;
               default -> throw new Error("unreachable");
-            }
+            },
+            activity.name
     );
   }
 

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
@@ -64,7 +64,7 @@ public record TypeUtilsPlanAdapter(Plan plan) implements gov.nasa.ammos.aerie.pr
       final var act = $.getValue();
       return new Directive<>(
           (A) deserializer.invoke(SerializedValue.of(act.serializedActivity().getArguments())),
-          "Name unavailable",
+          act.name(),
           id,
           act.serializedActivity().getTypeName(),
           act.anchorId() == null

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulePlanGrounder.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulePlanGrounder.java
@@ -40,7 +40,8 @@ public class SchedulePlanGrounder {
                 a.type().getName(),
                 a.arguments(),
                 (a.anchorId() == null) ? null : new ActivityDirectiveId(a.anchorId().id()),
-                a.anchoredToStart()
+                a.anchoredToStart(),
+                a.name()
             )))
         .filter($ -> $.getKey() != null)
         .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/CheckpointSimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/CheckpointSimulationFacade.java
@@ -125,7 +125,8 @@ public class CheckpointSimulationFacade implements SimulationFacade {
               act.getValue().startOffset(),
               act.getValue().serializedActivity(),
               replacements.getValue(),
-              act.getValue().anchoredToStart());
+              act.getValue().anchoredToStart(),
+              act.getValue().name());
           planSimCorrespondence.directiveIdActivityDirectiveMap().put(act.getKey(), replacementActivity);
         }
       }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacadeUtils.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacadeUtils.java
@@ -158,6 +158,7 @@ public class SimulationFacadeUtils {
         activity.startOffset(),
         serializedActivity,
         activity.anchorId(),
-        activity.anchoredToStart());
+        activity.anchoredToStart(),
+        activity.name());
   }
 }

--- a/type-utils/src/main/java/gov/nasa/jpl/aerie/types/ActivityDirective.java
+++ b/type-utils/src/main/java/gov/nasa/jpl/aerie/types/ActivityDirective.java
@@ -9,17 +9,20 @@ public record ActivityDirective(
     Duration startOffset,
     SerializedActivity serializedActivity,
     ActivityDirectiveId anchorId, // anchorId can be null
-    boolean anchoredToStart
+    boolean anchoredToStart,
+    String name
 ) {
   public ActivityDirective(
       final Duration startOffset,
       final String type,
       final Map<String, SerializedValue> arguments,
       final ActivityDirectiveId anchorId,
-      final boolean anchoredToStart) {
+      final boolean anchoredToStart,
+      String name) {
     this(startOffset,
          new SerializedActivity(type, (arguments != null) ? Map.copyOf(arguments) : null),
          anchorId,
-         anchoredToStart);
+         anchoredToStart,
+         name);
   }
 }


### PR DESCRIPTION
Procedural scheduling tracks activity names, but those names get lost when they pass through `gov.nasa.jpl.aerie.types.ActivityDirective`.

This PR adds a name field to `gov.nasa.jpl.aerie.types.ActivityDirective`.