### PR TITLE
Generic ActivityDirective

### DIFF
--- a/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/Plan.java
+++ b/e2e-tests/src/test/java/gov/nasa/jpl/aerie/e2e/types/Plan.java
@@ -10,9 +10,9 @@ public record Plan(
     String startTime,
     String duration,
     int revision,
-    List<ActivityDirective> activityDirectives
+    List<ActivityDirective<?>> activityDirectives
 ) {
-  public record ActivityDirective(
+  public record ActivityDirective<?>(
       int id,
       int planId,
       String type,
@@ -23,7 +23,7 @@ public record Plan(
       boolean anchoredToStart
   ) {
     public static ActivityDirective fromJSON(JsonObject json){
-      return new ActivityDirective(
+      return new ActivityDirective<?>(
           json.getInt("id"),
           json.getInt("plan_id"),
           json.getString("type"),

--- a/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulationUtility.java
+++ b/examples/banananation/src/test/java/gov/nasa/jpl/aerie/banananation/SimulationUtility.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ExecutionException;
 
 public final class SimulationUtility {
   public static SimulationResults
-  simulate(final Map<ActivityDirectiveId, ActivityDirective> schedule, final Duration simulationDuration) {
+  simulate(final Map<ActivityDirectiveId, ActivityDirective<?>> schedule, final Duration simulationDuration) {
     final var dataPath = Path.of(SimulationUtility.class.getResource("data/lorem_ipsum.txt").getPath());
     final var config = new Configuration(Configuration.DEFAULT_PLANT_COUNT, Configuration.DEFAULT_PRODUCER, dataPath, Configuration.DEFAULT_INITIAL_CONDITIONS);
     final var startTime = Instant.now();
@@ -44,14 +44,14 @@ public final class SimulationUtility {
   }
 
   @SafeVarargs
-  public static Map<ActivityDirectiveId, ActivityDirective> buildSchedule(final Pair<Duration, SerializedActivity>... activitySpecs) {
-    final var schedule = new HashMap<ActivityDirectiveId, ActivityDirective>();
+  public static Map<ActivityDirectiveId, ActivityDirective<?>> buildSchedule(final Pair<Duration, SerializedActivity>... activitySpecs) {
+    final var schedule = new HashMap<ActivityDirectiveId, ActivityDirective<?>>();
     long counter = 0;
 
     for (final var activitySpec : activitySpecs) {
       schedule.put(
           new ActivityDirectiveId(counter++),
-          new ActivityDirective(activitySpec.getLeft(), activitySpec.getRight(), null, true));
+          new ActivityDirective<?>(activitySpec.getLeft(), activitySpec.getRight(), null, true));
     }
 
     return schedule;

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooSimulationDuplicationTest.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/FooSimulationDuplicationTest.java
@@ -110,7 +110,7 @@ public class FooSimulationDuplicationTest {
         new MissionModelBuilder(),
         Instant.EPOCH,
         new Configuration());
-    final Map<ActivityDirectiveId, ActivityDirective> schedule = Map.ofEntries(
+    final Map<ActivityDirectiveId, ActivityDirective<?>> schedule = Map.ofEntries(
         activityFrom(1, MINUTE, "foo", Map.of("z", SerializedValue.of(123))),
         activityFrom(7, MINUTES, "foo", Map.of("z", SerializedValue.of(999)))
     );
@@ -151,7 +151,7 @@ public class FooSimulationDuplicationTest {
         new MissionModelBuilder(),
         Instant.EPOCH,
         new Configuration());
-    final Map<ActivityDirectiveId, ActivityDirective> schedule = Map.ofEntries(
+    final Map<ActivityDirectiveId, ActivityDirective<?>> schedule = Map.ofEntries(
         activityFrom(1, MINUTE, "foo", Map.of("z", SerializedValue.of(123))),
         activityFrom(7, MINUTES, "foo", Map.of("z", SerializedValue.of(999)))
     );
@@ -203,7 +203,7 @@ public class FooSimulationDuplicationTest {
         new MissionModelBuilder(),
         Instant.EPOCH,
         new Configuration());
-    final Map<ActivityDirectiveId, ActivityDirective> schedule = Map.ofEntries(
+    final Map<ActivityDirectiveId, ActivityDirective<?>> schedule = Map.ofEntries(
         activityFrom(1, MINUTE, "foo", Map.of("z", SerializedValue.of(123))),
         activityFrom(7, MINUTES, "foo", Map.of("z", SerializedValue.of(999)))
     );
@@ -255,16 +255,16 @@ public class FooSimulationDuplicationTest {
         new MissionModelBuilder(),
         Instant.EPOCH,
         new Configuration());
-    final Pair<ActivityDirectiveId, ActivityDirective> activity1 = activityFrom(
+    final Pair<ActivityDirectiveId, ActivityDirective<?>> activity1 = activityFrom(
         1,
         MINUTE,
         "foo",
         Map.of("z", SerializedValue.of(123)));
-    final Map<ActivityDirectiveId, ActivityDirective> schedule1 = Map.ofEntries(
+    final Map<ActivityDirectiveId, ActivityDirective<?>> schedule1 = Map.ofEntries(
         activity1,
         activityFrom(7, MINUTES, "foo", Map.of("z", SerializedValue.of(999)))
     );
-    final Map<ActivityDirectiveId, ActivityDirective> schedule2 = Map.ofEntries(
+    final Map<ActivityDirectiveId, ActivityDirective<?>> schedule2 = Map.ofEntries(
         activity1,
         activityFrom(390, SECONDS, "foo", Map.of("z", SerializedValue.of(999)))
     );
@@ -321,12 +321,12 @@ public class FooSimulationDuplicationTest {
 
   private static long nextActivityDirectiveId = 0L;
 
-  private static Pair<ActivityDirectiveId, ActivityDirective> activityFrom(final long quantity, final Duration unit, final String type, final Map<String, SerializedValue> args) {
+  private static Pair<ActivityDirectiveId, ActivityDirective<?>> activityFrom(final long quantity, final Duration unit, final String type, final Map<String, SerializedValue> args) {
     return activityFrom(Duration.of(quantity, unit), type, args);
   }
 
-  private static Pair<ActivityDirectiveId, ActivityDirective> activityFrom(final Duration startOffset, final String type, final Map<String, SerializedValue> args) {
-    return Pair.of(new ActivityDirectiveId(nextActivityDirectiveId++), new ActivityDirective(startOffset, type, args, null, true));
+  private static Pair<ActivityDirectiveId, ActivityDirective<?>> activityFrom(final Duration startOffset, final String type, final Map<String, SerializedValue> args) {
+    return Pair.of(new ActivityDirectiveId(nextActivityDirectiveId++), new ActivityDirective<?>(startOffset, type, args, null, true));
   }
 
 
@@ -371,7 +371,7 @@ public class FooSimulationDuplicationTest {
       final MissionModel<?> missionModel,
       final CachedSimulationEngine cachedSimulationEngine,
       final List<Duration> desiredCheckpoints,
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final CachedEngineStore cachedEngineStore,
       final SimulationEngineConfiguration simulationEngineConfiguration
   ) {
@@ -395,7 +395,7 @@ public class FooSimulationDuplicationTest {
   static SimulationResults simulateWithCheckpoints(
       final MissionModel<?> missionModel,
       final List<Duration> desiredCheckpoints,
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final CachedEngineStore cachedEngineStore,
       final SimulationEngineConfiguration simulationEngineConfiguration
   ) {

--- a/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
+++ b/examples/foo-missionmodel/src/test/java/gov/nasa/jpl/aerie/foomissionmodel/SimulateMapSchedule.java
@@ -62,8 +62,8 @@ public class SimulateMapSchedule {
     });
   }
 
-  private static Map<ActivityDirectiveId, ActivityDirective> loadSchedule() {
-    final var schedule = new HashMap<ActivityDirectiveId, ActivityDirective>();
+  private static Map<ActivityDirectiveId, ActivityDirective<?>> loadSchedule() {
+    final var schedule = new HashMap<ActivityDirectiveId, ActivityDirective<?>>();
     long counter = 0;
 
     final var planJson = Json.createReader(SimulateMapSchedule.class.getResourceAsStream("plan.json")).readValue();
@@ -78,7 +78,7 @@ public class SimulateMapSchedule {
 
       schedule.put(
           new ActivityDirectiveId(counter++),
-          new ActivityDirective(
+          new ActivityDirective<?>(
               duration(deferInMicroseconds, MICROSECONDS),
               new SerializedActivity(activityType, arguments),
               null,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CachedSimulationEngine.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CachedSimulationEngine.java
@@ -7,13 +7,14 @@ import gov.nasa.jpl.aerie.merlin.protocol.driver.Topic;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 
 import java.time.Instant;
 import java.util.Map;
 
 public record CachedSimulationEngine(
       Duration endsAt,
-      Map<ActivityDirectiveId, ActivityDirective> activityDirectives,
+      Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives,
       SimulationEngine simulationEngine,
       Topic<ActivityDirectiveId> activityTopic,
       MissionModel<?> missionModel,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CheckpointSimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/CheckpointSimulationDriver.java
@@ -42,7 +42,7 @@ public class CheckpointSimulationDriver {
    * @return the best cached engine as well as the map of corresponding activity ids for this engine
    */
   public static Optional<Pair<CachedSimulationEngine, Map<ActivityDirectiveId, ActivityDirectiveId>>> bestCachedEngine(
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final List<CachedSimulationEngine> cachedEngines,
       final Duration planDuration
   ) {
@@ -70,7 +70,7 @@ public class CheckpointSimulationDriver {
           invalidationTime = min(invalidationTime, minimumStartTimes.get(activity.getKey()));
         }
       }
-      final var allActs = new HashMap<ActivityDirectiveId, ActivityDirective>();
+      final var allActs = new HashMap<ActivityDirectiveId, ActivityDirective<?>>();
       allActs.putAll(cachedEngine.activityDirectives());
       allActs.putAll(scheduledActivities);
       final var minimumStartTimeOfActsInCache = getMinimumStartTimes(allActs, planDuration);
@@ -110,7 +110,7 @@ public class CheckpointSimulationDriver {
   }
 
   private static Map<ActivityDirectiveId, Duration> getMinimumStartTimes(
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final Duration planDuration)
   {
     //For an anchored activity, it's minimum invalidationTime would be the sum of all startOffsets in its anchor chain
@@ -140,7 +140,7 @@ public class CheckpointSimulationDriver {
       Duration currentTime,
       Duration nextTime,
       SimulationEngine simulationEngine,
-      Map<ActivityDirectiveId, ActivityDirective> schedule,
+      Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       Map<ActivityDirectiveId, SpanId> activityDirectiveIdSpanIdMap
   ) {}
 
@@ -164,7 +164,7 @@ public class CheckpointSimulationDriver {
    */
   public static <Model> SimulationResultsComputerInputs simulateWithCheckpoints(
       final MissionModel<Model> missionModel,
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final Instant simulationStartTime,
       final Duration simulationDuration,
       final Instant planStartTime,
@@ -213,7 +213,7 @@ public class CheckpointSimulationDriver {
       // Schedule all activities.
       final var toSchedule = new LinkedHashSet<ActivityDirectiveId>();
       toSchedule.add(null);
-      final var activitiesToBeScheduledNow = new HashMap<ActivityDirectiveId, ActivityDirective>();
+      final var activitiesToBeScheduledNow = new HashMap<ActivityDirectiveId, ActivityDirective<?>>();
       if (resolved.get(null) != null) {
         for (final var r : resolved.get(null)) {
           activitiesToBeScheduledNow.put(r.getKey(), schedule.get(r.getKey()));
@@ -349,7 +349,7 @@ public class CheckpointSimulationDriver {
 
   private static <Model> Map<ActivityDirectiveId, SpanId> scheduleActivities(
       final Set<ActivityDirectiveId> toScheduleNow,
-      final Map<ActivityDirectiveId, ActivityDirective> completeSchedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> completeSchedule,
       final HashMap<ActivityDirectiveId, List<Pair<ActivityDirectiveId, Duration>>> resolved,
       final MissionModel<Model> missionModel,
       final SimulationEngine engine,

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationDriver.java
@@ -27,7 +27,7 @@ import java.util.function.Supplier;
 public final class SimulationDriver {
   public static <Model> SimulationResults simulate(
       final MissionModel<Model> missionModel,
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final Instant simulationStartTime,
       final Duration simulationDuration,
       final Instant planStartTime,
@@ -48,7 +48,7 @@ public final class SimulationDriver {
 
   public static <Model> SimulationResults simulate(
       final MissionModel<Model> missionModel,
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final Instant simulationStartTime,
       final Duration simulationDuration,
       final Instant planStartTime,
@@ -160,7 +160,7 @@ public final class SimulationDriver {
   }
 
   private static <Model> void scheduleActivities(
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final HashMap<ActivityDirectiveId, List<Pair<ActivityDirectiveId, Duration>>> resolved,
       final MissionModel<Model> missionModel,
       final SimulationEngine engine,
@@ -191,7 +191,7 @@ public final class SimulationDriver {
   private static <Model, Output> TaskFactory<Unit> makeTaskFactory(
       final ActivityDirectiveId directiveId,
       final TaskFactory<Output> taskFactory,
-      final Map<ActivityDirectiveId, ActivityDirective> schedule,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> schedule,
       final HashMap<ActivityDirectiveId, List<Pair<ActivityDirectiveId, Duration>>> resolved,
       final MissionModel<Model> missionModel,
       final Topic<ActivityDirectiveId> activityTopic

--- a/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/StartOffsetReducer.java
+++ b/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/StartOffsetReducer.java
@@ -3,6 +3,7 @@ package gov.nasa.jpl.aerie.merlin.driver;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
@@ -16,10 +17,10 @@ import java.util.concurrent.RecursiveTask;
 
 public class StartOffsetReducer extends RecursiveTask<HashMap<ActivityDirectiveId, List<Pair<ActivityDirectiveId, Duration>>>> {
   private final Duration planDuration;
-  private final Map<ActivityDirectiveId, ActivityDirective> completeMapOfDirectives;
-  private final Map<ActivityDirectiveId, ActivityDirective> activityDirectivesToProcess;
+  private final Map<ActivityDirectiveId, ActivityDirective<?>> completeMapOfDirectives;
+  private final Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectivesToProcess;
 
-  public StartOffsetReducer(Duration planDuration, Map<ActivityDirectiveId, ActivityDirective> activityDirectives){
+  public StartOffsetReducer(Duration planDuration, Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives){
     this.planDuration = planDuration;
     if(activityDirectives == null) {
       this.completeMapOfDirectives = Map.of();
@@ -32,8 +33,8 @@ public class StartOffsetReducer extends RecursiveTask<HashMap<ActivityDirectiveI
 
   private StartOffsetReducer(
       Duration planDuration,
-      Map<ActivityDirectiveId, ActivityDirective> activityDirectives,
-      Map<ActivityDirectiveId, ActivityDirective> allActivityDirectives){
+      Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives,
+      Map<ActivityDirectiveId, ActivityDirective<?>> allActivityDirectives){
     this.planDuration = planDuration;
     this.activityDirectivesToProcess = activityDirectives;
     this.completeMapOfDirectives = allActivityDirectives;
@@ -56,8 +57,8 @@ public class StartOffsetReducer extends RecursiveTask<HashMap<ActivityDirectiveI
       return toReturn;
     }
     // else split the map in half and process each side in parallel
-    final var leftDirectivesToProcess = new HashMap<ActivityDirectiveId, ActivityDirective>(activityDirectivesToProcess.size()/2);
-    final var rightDirectivesToProcess = new HashMap<ActivityDirectiveId, ActivityDirective>(activityDirectivesToProcess.size()/2);
+    final var leftDirectivesToProcess = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(activityDirectivesToProcess.size()/2);
+    final var rightDirectivesToProcess = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(activityDirectivesToProcess.size()/2);
     int count=0;
     for(var entry : activityDirectivesToProcess.entrySet()) {
       (count<(activityDirectivesToProcess.size()/2) ? leftDirectivesToProcess : rightDirectivesToProcess).put(entry.getKey(), entry.getValue());

--- a/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/AnchorSimulationTest.java
+++ b/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/AnchorSimulationTest.java
@@ -43,19 +43,19 @@ public final class AnchorSimulationTest {
     @Test
     @DisplayName("Activities anchored to the plan depend on no activities")
     public void activitiesWithoutAnchor() {
-      final var activityDirectives = new HashMap<ActivityDirectiveId, ActivityDirective>(15);
+      final var activityDirectives = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(15);
 
       // Anchored to Plan Start (only positive is allowed)
       for (long l = 0; l < 5; l++) {
         activityDirectives.put(
             new ActivityDirectiveId(l),
-            new ActivityDirective(Duration.of(l, Duration.SECONDS), serializedActivity, null, true));
+            new ActivityDirective<?>(Duration.of(l, Duration.SECONDS), serializedActivity, null, true));
       }
       // Anchored to Plan End, positive
       for (long l = 5; l < 10; l++) {
         activityDirectives.put(
             new ActivityDirectiveId(l),
-            new ActivityDirective(Duration.of(l, Duration.SECONDS),
+            new ActivityDirective<?>(Duration.of(l, Duration.SECONDS),
                                   serializedActivity,
                                   null,
                                   false));
@@ -64,7 +64,7 @@ public final class AnchorSimulationTest {
       for (long l = 10; l < 15; l++) {
         activityDirectives.put(
             new ActivityDirectiveId(l),
-            new ActivityDirective(Duration.of(-l, Duration.SECONDS),
+            new ActivityDirective<?>(Duration.of(-l, Duration.SECONDS),
                                   serializedActivity,
                                   null,
                                   false));
@@ -100,24 +100,24 @@ public final class AnchorSimulationTest {
     public void startTimeChains() {
       // Check chains and values
       final var minusOneMinute = Duration.of(-60, Duration.SECONDS);
-      final var activityDirectives = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
+      final var activityDirectives = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
 
       activityDirectives.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(oneMinute, serializedActivity, null, true));
+          new ActivityDirective<?>(oneMinute, serializedActivity, null, true));
 
       for (long l = 1; l < 400; l++) {
         if ((l & 1) == 0) { // If even
           activityDirectives.put(
               new ActivityDirectiveId(l),
-              new ActivityDirective(oneMinute,
+              new ActivityDirective<?>(oneMinute,
                                     serializedActivity,
                                     new ActivityDirectiveId(l - 1),
                                     true));
         } else {
           activityDirectives.put(
               new ActivityDirectiveId(l),
-              new ActivityDirective(minusOneMinute,
+              new ActivityDirective<?>(minusOneMinute,
                                     serializedActivity,
                                     new ActivityDirectiveId(l - 1),
                                     true));
@@ -148,34 +148,34 @@ public final class AnchorSimulationTest {
     @DisplayName("Anchor chains following an anchor on an activity's end time depend on that activity")
     public void chainsWithEndTimeAnchors() {
       //check chains and values
-      final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
-      final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
+      final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
+      final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
 
       allEndTimeAnchors.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(oneMinute, serializedActivity, null, true));
+          new ActivityDirective<?>(oneMinute, serializedActivity, null, true));
       endTimeAnchorEveryFifth.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(oneMinute, serializedActivity, null, true));
+          new ActivityDirective<?>(oneMinute, serializedActivity, null, true));
 
       for (long l = 1; l < 400; l++) {
         allEndTimeAnchors.put(
             new ActivityDirectiveId(l),
-            new ActivityDirective(oneMinute,
+            new ActivityDirective<?>(oneMinute,
                                   serializedActivity,
                                   new ActivityDirectiveId(l - 1),
                                   false));
         if (l % 5 == 0) {
           endTimeAnchorEveryFifth.put(
               new ActivityDirectiveId(l),
-              new ActivityDirective(oneMinute,
+              new ActivityDirective<?>(oneMinute,
                                     serializedActivity,
                                     new ActivityDirectiveId(l - 1),
                                     false));
         } else {
           endTimeAnchorEveryFifth.put(
               new ActivityDirectiveId(l),
-              new ActivityDirective(oneMinute,
+              new ActivityDirective<?>(oneMinute,
                                     serializedActivity,
                                     new ActivityDirectiveId(l - 1),
                                     true));
@@ -233,32 +233,32 @@ public final class AnchorSimulationTest {
       // This is not a performance test.
       // This test proves why we can use list.addAll() during the join step instead of using a set to remove duplicates
       // Odd vs Even because the activities are divided in half when the Reducer splits
-      final var oddAmountActivities = new HashMap<ActivityDirectiveId, ActivityDirective>(12001);
-      final var evenAmountActivities = new HashMap<ActivityDirectiveId, ActivityDirective>(12000);
+      final var oddAmountActivities = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(12001);
+      final var evenAmountActivities = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(12000);
 
       oddAmountActivities.put(
           new ActivityDirectiveId(1),
-          new ActivityDirective(Duration.of(1, Duration.SECONDS), serializedActivity, null, true));
+          new ActivityDirective<?>(Duration.of(1, Duration.SECONDS), serializedActivity, null, true));
       evenAmountActivities.put(
           new ActivityDirectiveId(1),
-          new ActivityDirective(Duration.of(1, Duration.SECONDS), serializedActivity, null, true));
+          new ActivityDirective<?>(Duration.of(1, Duration.SECONDS), serializedActivity, null, true));
       for (long l = 2; l < 12001; l++) {
         oddAmountActivities.put(
             new ActivityDirectiveId(l),
-            new ActivityDirective(Duration.of(l, Duration.SECONDS),
+            new ActivityDirective<?>(Duration.of(l, Duration.SECONDS),
                                   serializedActivity,
                                   new ActivityDirectiveId(l - 1),
                                   true));
         evenAmountActivities.put(
             new ActivityDirectiveId(l),
-            new ActivityDirective(Duration.of(l, Duration.SECONDS),
+            new ActivityDirective<?>(Duration.of(l, Duration.SECONDS),
                                   serializedActivity,
                                   new ActivityDirectiveId(l - 1),
                                   true));
       }
       oddAmountActivities.put(
           new ActivityDirectiveId(12001),
-          new ActivityDirective(Duration.of(0, Duration.SECONDS), serializedActivity, null, true));
+          new ActivityDirective<?>(Duration.of(0, Duration.SECONDS), serializedActivity, null, true));
 
       final var oddReduced = new StartOffsetReducer(tenDays, oddAmountActivities).compute();
       final var evenReduced = new StartOffsetReducer(tenDays, evenAmountActivities).compute();
@@ -500,7 +500,7 @@ public final class AnchorSimulationTest {
         int maxLevel,
         int currentLevel,
         long parentNode,
-        Map<ActivityDirectiveId, ActivityDirective> activitiesToSimulate,
+        Map<ActivityDirectiveId, ActivityDirective<?>> activitiesToSimulate,
         Map<ActivityInstanceId, ActivityInstance> simulatedActivities)
     {
       if (currentLevel > maxLevel) return;
@@ -508,7 +508,7 @@ public final class AnchorSimulationTest {
         long curElement = parentNode * 5 + i;
         activitiesToSimulate.put(
             new ActivityDirectiveId(curElement),
-            new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(parentNode), false));
+            new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(parentNode), false));
         simulatedActivities.put(
             new ActivityInstanceId(curElement),
             new ActivityInstance(
@@ -542,7 +542,7 @@ public final class AnchorSimulationTest {
     @DisplayName("Activities depending on no activities simulate at the correct time")
     public void activitiesAnchoredToPlan() {
       final var minusOneMinute = Duration.of(-60, Duration.SECONDS);
-      final var resolveToPlanStartAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(415);
+      final var resolveToPlanStartAnchors = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(415);
       final Map<ActivityInstanceId, ActivityInstance> simulatedActivities = new HashMap<>(415);
 
       // Anchored to Plan Start (only positive is allowed)
@@ -550,7 +550,7 @@ public final class AnchorSimulationTest {
         final var activityDirectiveId = new ActivityDirectiveId(l);
         resolveToPlanStartAnchors.put(
             activityDirectiveId,
-            new ActivityDirective(Duration.of(l, Duration.SECONDS), serializedDelayDirective, null, true));
+            new ActivityDirective<?>(Duration.of(l, Duration.SECONDS), serializedDelayDirective, null, true));
         simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
             serializedDelayDirective.getTypeName(),
             Map.of(),
@@ -567,7 +567,7 @@ public final class AnchorSimulationTest {
         final var activityDirectiveId = new ActivityDirectiveId(l);
         resolveToPlanStartAnchors.put(
             activityDirectiveId,
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 // Minutes so they finish by simulation end
                 Duration.of(-l, Duration.MINUTES),
                 serializedDelayDirective,
@@ -588,7 +588,7 @@ public final class AnchorSimulationTest {
       // Chained to plan start
       resolveToPlanStartAnchors.put(
           new ActivityDirectiveId(15),
-          new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(0), true));
+          new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(0), true));
       simulatedActivities.put(new ActivityInstanceId(15), new ActivityInstance(
           serializedDelayDirective.getTypeName(),
           Map.of(),
@@ -605,7 +605,7 @@ public final class AnchorSimulationTest {
         if ((l & 1) == 0) { // If even
           resolveToPlanStartAnchors.put(
               activityDirectiveId,
-              new ActivityDirective(oneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
+              new ActivityDirective<?>(oneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
           simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
               serializedDelayDirective.getTypeName(),
               Map.of(),
@@ -619,7 +619,7 @@ public final class AnchorSimulationTest {
         } else {
           resolveToPlanStartAnchors.put(
               activityDirectiveId,
-              new ActivityDirective(minusOneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
+              new ActivityDirective<?>(minusOneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
           simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
               serializedDelayDirective.getTypeName(),
               Map.of(),
@@ -659,17 +659,17 @@ public final class AnchorSimulationTest {
     @Test
     @DisplayName("Activities depending on another activities simulate at the correct time")
     public void activitiesAnchoredToOtherActivities() {
-      final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
-      final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
+      final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
+      final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
       final Map<ActivityInstanceId, ActivityInstance> simulatedActivities = new HashMap<>(800);
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(800);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(800);
 
       allEndTimeAnchors.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(oneMinute, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(oneMinute, serializedDelayDirective, null, true));
       endTimeAnchorEveryFifth.put(
           new ActivityDirectiveId(400),
-          new ActivityDirective(oneMinute, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(oneMinute, serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(0),
           new ActivityInstance(
@@ -699,7 +699,7 @@ public final class AnchorSimulationTest {
 
         allEndTimeAnchors.put(
             activityDirectiveIdAETA,
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 oneMinute,
                 serializedDelayDirective,
                 new ActivityDirectiveId(l - 1),
@@ -719,7 +719,7 @@ public final class AnchorSimulationTest {
         if (k % 5 == 0) {
           endTimeAnchorEveryFifth.put(
               activityDirectiveIdEveryFifth,
-              new ActivityDirective(
+              new ActivityDirective<?>(
                   oneMinute,
                   serializedDelayDirective,
                   new ActivityDirectiveId(k - 1),
@@ -728,7 +728,7 @@ public final class AnchorSimulationTest {
         } else {
           endTimeAnchorEveryFifth.put(
               activityDirectiveIdEveryFifth,
-              new ActivityDirective(
+              new ActivityDirective<?>(
                   oneMinute,
                   serializedDelayDirective,
                   new ActivityDirectiveId(k - 1),
@@ -781,7 +781,7 @@ public final class AnchorSimulationTest {
       // and two NDs cannot be adjacent to each other, there are 20 permutations.
 
       // In order to have fewer activities and more complex subtrees, the first and second elements of a set of sequences will be reused when possible
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(23);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(23);
       // NOTE: This list is intentionally keyed on ActivityDirectiveId, not on SimulatedActivityId.
       // Additionally, because we do not know the order the child activities will generate in, DecompositionDirectives will have a List.of() rather than the correct value
       final var topLevelSimulatedActivities = new HashMap<ActivityDirectiveId, ActivityInstance>(23);
@@ -790,16 +790,16 @@ public final class AnchorSimulationTest {
       // ND <-s- D <-s- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(1),
-          new ActivityDirective(Duration.ZERO, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, null, true));
       activitiesToSimulate.put(
           new ActivityDirectiveId(2),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(1),
                                 true));
       activitiesToSimulate.put(
           new ActivityDirectiveId(3),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(2),
                                 true));
@@ -840,7 +840,7 @@ public final class AnchorSimulationTest {
       // ND <-s- D <-e- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(4),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(2),
                                 false));
@@ -859,7 +859,7 @@ public final class AnchorSimulationTest {
       // ND <-s- D <-s- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(5),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(2),
                                 true));
@@ -878,7 +878,7 @@ public final class AnchorSimulationTest {
       // ND <-s- D <-e- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(6),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(2),
                                 false));
@@ -897,13 +897,13 @@ public final class AnchorSimulationTest {
       // ND <-e- D <-s- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(7),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(1),
                                 false));
       activitiesToSimulate.put(
           new ActivityDirectiveId(8),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(7),
                                 true));
@@ -933,7 +933,7 @@ public final class AnchorSimulationTest {
       // ND <-e- D <-e- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(9),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(7),
                                 false));
@@ -952,7 +952,7 @@ public final class AnchorSimulationTest {
       // ND <-e- D <-s- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(10),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(7),
                                 true));
@@ -971,7 +971,7 @@ public final class AnchorSimulationTest {
       // ND <-e- D <-e- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(11),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(7),
                                 false));
@@ -990,7 +990,7 @@ public final class AnchorSimulationTest {
       // D <-s- D <-s- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(12),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(3),
                                 true));
@@ -1009,7 +1009,7 @@ public final class AnchorSimulationTest {
       // D <-s- D <-e- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(13),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(3),
                                 false));
@@ -1028,7 +1028,7 @@ public final class AnchorSimulationTest {
       // D <-s- D <-s- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(14),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(3),
                                 true));
@@ -1047,7 +1047,7 @@ public final class AnchorSimulationTest {
       // D <-s- D <-e- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(15),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(3),
                                 false));
@@ -1066,7 +1066,7 @@ public final class AnchorSimulationTest {
       // D <-e- D <-s- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(16),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(4),
                                 true));
@@ -1085,7 +1085,7 @@ public final class AnchorSimulationTest {
       // D <-e- D <-e- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(17),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(4),
                                 false));
@@ -1104,7 +1104,7 @@ public final class AnchorSimulationTest {
       // D <-e- D <-s- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(18),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(4),
                                 true));
@@ -1123,7 +1123,7 @@ public final class AnchorSimulationTest {
       // D <-e- D <-e- ND
       activitiesToSimulate.put(
           new ActivityDirectiveId(19),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDelayDirective,
                                 new ActivityDirectiveId(4),
                                 false));
@@ -1142,7 +1142,7 @@ public final class AnchorSimulationTest {
       // D <-s- ND <-s- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(20),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(14),
                                 true));
@@ -1161,7 +1161,7 @@ public final class AnchorSimulationTest {
       // D <-s- ND <-e- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(21),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(14),
                                 false));
@@ -1180,7 +1180,7 @@ public final class AnchorSimulationTest {
       // D <-e- ND <-s- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(22),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(15),
                                 true));
@@ -1199,7 +1199,7 @@ public final class AnchorSimulationTest {
       // D <-e- ND <-e- D
       activitiesToSimulate.put(
           new ActivityDirectiveId(23),
-          new ActivityDirective(Duration.ZERO,
+          new ActivityDirective<?>(Duration.ZERO,
                                 serializedDecompositionDirective,
                                 new ActivityDirectiveId(15),
                                 false));
@@ -1323,12 +1323,12 @@ public final class AnchorSimulationTest {
       // Full and complete 5-ary tree,  6 levels deep
       // Number of activity directives = 5^0 + 5^1 + 5^2 + 5^3 + 5^4 + 5^5 = 3906
 
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(3906);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(3906);
       final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(3906);
 
       activitiesToSimulate.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(Duration.ZERO, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(0),
           new ActivityInstance(

--- a/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/TemporalSubsetSimulationTests.java
+++ b/merlin-driver/src/test/java/gov/nasa/jpl/aerie/merlin/driver/TemporalSubsetSimulationTests.java
@@ -76,12 +76,12 @@ public class TemporalSubsetSimulationTests {
   public void simulateFirstHalf(){
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(120);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(1);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(240);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(240);
 
     for(int i = 0; i < 120; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(i),
           new ActivityInstance(
@@ -98,7 +98,7 @@ public class TemporalSubsetSimulationTests {
     for(int i = 120; i < 240; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     // Activity 120 won't be finished since it starts at the simulation end time
@@ -139,12 +139,12 @@ public class TemporalSubsetSimulationTests {
   @DisplayName("Ten-day plan, no anchors: Simulate second half of plan")
   public void simulateSecondHalf(){
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(120);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(240);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(240);
 
     for(int i = 0; i < 120; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     for(int i = 120; i < 240; ++i){
@@ -161,7 +161,7 @@ public class TemporalSubsetSimulationTests {
               computedAttributes));
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     // Assert Simulation results
@@ -192,18 +192,18 @@ public class TemporalSubsetSimulationTests {
   void simulateMiddle() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(120);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(1);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(240);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(240);
 
     for(int i = 0; i < 72; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     for(int i = 72; i < 192; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(i),
           new ActivityInstance(
@@ -220,7 +220,7 @@ public class TemporalSubsetSimulationTests {
     for(int i = 192; i < 240; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     // Activity 192 won't be finished since it starts at the simulation end time
@@ -262,12 +262,12 @@ public class TemporalSubsetSimulationTests {
   void simulateBeforePlanStart() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(120);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(1);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(240);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(240);
 
     for(int i = -48; i < 72; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(i),
           new ActivityInstance(
@@ -284,7 +284,7 @@ public class TemporalSubsetSimulationTests {
     for(int i = 72; i < 240; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     // Activity 72 won't be finished since it starts at the simulation end time
@@ -326,18 +326,18 @@ public class TemporalSubsetSimulationTests {
   void simulateAfterPlanEnd() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(120);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(1);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(240);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(240);
 
     for(int i = 72; i < 192; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     for(int i = 192; i < 312; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(i),
           new ActivityInstance(
@@ -379,13 +379,13 @@ public class TemporalSubsetSimulationTests {
   void simulateAroundAnchors() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(16);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(0);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(37);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(37);
 
     // 4 sets of activities, each size 4, Hours 3, 4, 5, 6, 7
     // Base
     activitiesInPlan.put(
         new ActivityDirectiveId(0),
-        new ActivityDirective(Duration.of(3, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(3, Duration.HOURS), serializedDelayDirective, null, true));
     simulatedActivities.put(
         new ActivityInstanceId(0),
         new ActivityInstance(
@@ -401,7 +401,7 @@ public class TemporalSubsetSimulationTests {
     // Set 1: Start Time Anchor Chain
     activitiesInPlan.put(
         new ActivityDirectiveId(1),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), true));
     simulatedActivities.put(
         new ActivityInstanceId(1),
         new ActivityInstance(
@@ -415,7 +415,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(2),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(1), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(1), true));
     simulatedActivities.put(
         new ActivityInstanceId(2),
         new ActivityInstance(
@@ -429,7 +429,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(3),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(2), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(2), true));
     simulatedActivities.put(
         new ActivityInstanceId(3),
         new ActivityInstance(
@@ -443,7 +443,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(4),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(3), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(3), true));
     simulatedActivities.put(
         new ActivityInstanceId(4),
         new ActivityInstance(
@@ -459,7 +459,7 @@ public class TemporalSubsetSimulationTests {
     // Set 2: End Time Anchor Chain
     activitiesInPlan.put(
         new ActivityDirectiveId(5),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), false));
     simulatedActivities.put(
         new ActivityInstanceId(5),
         new ActivityInstance(
@@ -473,7 +473,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(6),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(5), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(5), false));
     simulatedActivities.put(
         new ActivityInstanceId(6),
         new ActivityInstance(
@@ -487,7 +487,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(7),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(6), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(6), false));
     simulatedActivities.put(
         new ActivityInstanceId(7),
         new ActivityInstance(
@@ -501,7 +501,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(8),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(7), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(7), false));
     simulatedActivities.put(
         new ActivityInstanceId(8),
         new ActivityInstance(
@@ -517,7 +517,7 @@ public class TemporalSubsetSimulationTests {
     // Set 3: Start-End-Start-End Anchor Chain
     activitiesInPlan.put(
         new ActivityDirectiveId(9),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), true));
     simulatedActivities.put(
         new ActivityInstanceId(9),
         new ActivityInstance(
@@ -531,7 +531,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(10),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(9), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(9), false));
     simulatedActivities.put(
         new ActivityInstanceId(10),
         new ActivityInstance(
@@ -545,7 +545,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(11),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(10), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(10), true));
     simulatedActivities.put(
         new ActivityInstanceId(11),
         new ActivityInstance(
@@ -559,7 +559,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(12),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(11), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(11), false));
     simulatedActivities.put(
         new ActivityInstanceId(12),
         new ActivityInstance(
@@ -575,7 +575,7 @@ public class TemporalSubsetSimulationTests {
     for(int i = 0; i < 24; i++){
       activitiesInPlan.put(
           new ActivityDirectiveId(i+13),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
     // Set 4: No Anchors
     for(int i = 3; i < 8; i++){
@@ -620,30 +620,30 @@ public class TemporalSubsetSimulationTests {
   void simulateStartBetweenAnchors() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(8);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(0);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(37);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(37);
 
     // Three chains, two interrupted (one end-time, one start-time), one not
     // Chain 1: Interrupted, end-time
     activitiesInPlan.put(
         new ActivityDirectiveId(0),
-        new ActivityDirective(Duration.of(2, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(2, Duration.HOURS), serializedDelayDirective, null, true));
     activitiesInPlan.put(
         new ActivityDirectiveId(1),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), false));
     activitiesInPlan.put(
         new ActivityDirectiveId(2),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(1), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(1), false));
     activitiesInPlan.put(
         new ActivityDirectiveId(3),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(2), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(2), false));
 
     // Chain 2: Interrupted, start-time
     activitiesInPlan.put(
         new ActivityDirectiveId(4),
-        new ActivityDirective(Duration.of(2, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(2, Duration.HOURS), serializedDelayDirective, null, true));
     activitiesInPlan.put(
         new ActivityDirectiveId(5),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(4), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(4), true));
     simulatedActivities.put(
         new ActivityInstanceId(5),
         new ActivityInstance(
@@ -657,7 +657,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(6),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(5), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(5), true));
     simulatedActivities.put(
         new ActivityInstanceId(6),
         new ActivityInstance(
@@ -671,7 +671,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(7),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(6), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(6), true));
     simulatedActivities.put(
         new ActivityInstanceId(7),
         new ActivityInstance(
@@ -687,7 +687,7 @@ public class TemporalSubsetSimulationTests {
     // Chain 3: Uninterrupted
     activitiesInPlan.put(
         new ActivityDirectiveId(8),
-        new ActivityDirective(Duration.of(3, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(3, Duration.HOURS), serializedDelayDirective, null, true));
     simulatedActivities.put(
         new ActivityInstanceId(8),
         new ActivityInstance(
@@ -701,7 +701,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(9),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(8), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(8), true));
     simulatedActivities.put(
         new ActivityInstanceId(9),
         new ActivityInstance(
@@ -715,7 +715,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(10),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(9), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(9), true));
     simulatedActivities.put(
         new ActivityInstanceId(10),
         new ActivityInstance(
@@ -729,7 +729,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(11),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(10), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(10), true));
     simulatedActivities.put(
         new ActivityInstanceId(11),
         new ActivityInstance(
@@ -745,12 +745,12 @@ public class TemporalSubsetSimulationTests {
     for(int i = 0; i < 3; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i+24),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
     for(int i = 8; i < 24; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i+24),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     // Assert Simulation results
@@ -781,13 +781,13 @@ public class TemporalSubsetSimulationTests {
   void simulateEndBetweenAnchors() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(8);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(0);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(37);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(37);
 
     // Three chains, two interrupted (one end-time, one start-time), one not
     // Chain 1: Interrupted, end-time
     activitiesInPlan.put(
         new ActivityDirectiveId(0),
-        new ActivityDirective(Duration.of(5, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(5, Duration.HOURS), serializedDelayDirective, null, true));
     simulatedActivities.put(
         new ActivityInstanceId(0),
         new ActivityInstance(
@@ -801,7 +801,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(1),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(0), false));
     simulatedActivities.put(
         new ActivityInstanceId(1),
         new ActivityInstance(
@@ -815,7 +815,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(2),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(1), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(1), false));
     simulatedActivities.put(
         new ActivityInstanceId(2),
         new ActivityInstance(
@@ -829,12 +829,12 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(3),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(2), false));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(2), false));
 
     // Chain 2: Interrupted, start-time
     activitiesInPlan.put(
         new ActivityDirectiveId(4),
-        new ActivityDirective(Duration.of(5, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(5, Duration.HOURS), serializedDelayDirective, null, true));
     simulatedActivities.put(
         new ActivityInstanceId(4),
         new ActivityInstance(
@@ -848,7 +848,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(5),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(4), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(4), true));
     simulatedActivities.put(
         new ActivityInstanceId(5),
         new ActivityInstance(
@@ -862,7 +862,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(6),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(5), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(5), true));
     simulatedActivities.put(
         new ActivityInstanceId(6),
         new ActivityInstance(
@@ -876,12 +876,12 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(7),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(6), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(6), true));
 
     // Chain 3: Uninterrupted
     activitiesInPlan.put(
         new ActivityDirectiveId(8),
-        new ActivityDirective(Duration.of(3, Duration.HOURS), serializedDelayDirective, null, true));
+        new ActivityDirective<?>(Duration.of(3, Duration.HOURS), serializedDelayDirective, null, true));
     simulatedActivities.put(
         new ActivityInstanceId(8),
         new ActivityInstance(
@@ -895,7 +895,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(9),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(8), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(8), true));
     simulatedActivities.put(
         new ActivityInstanceId(9),
         new ActivityInstance(
@@ -909,7 +909,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(10),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(9), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(9), true));
     simulatedActivities.put(
         new ActivityInstanceId(10),
         new ActivityInstance(
@@ -923,7 +923,7 @@ public class TemporalSubsetSimulationTests {
             computedAttributes));
     activitiesInPlan.put(
         new ActivityDirectiveId(11),
-        new ActivityDirective(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(10), true));
+        new ActivityDirective<?>(Duration.of(1, Duration.HOURS), serializedDelayDirective, new ActivityDirectiveId(10), true));
     simulatedActivities.put(
         new ActivityInstanceId(11),
         new ActivityInstance(
@@ -940,12 +940,12 @@ public class TemporalSubsetSimulationTests {
     for(int i = 0; i < 3; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i+24),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
     for(int i = 8; i < 24; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i+24),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
 
     // Assert Simulation results
@@ -976,12 +976,12 @@ public class TemporalSubsetSimulationTests {
   void simulateNoDuration() {
     final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(0);
     final var unfinishedActivities = new HashMap<ActivityInstanceId, UnfinishedActivity>(1);
-    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective>(24);
+    final var activitiesInPlan = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(24);
 
     for(int i = 0; i < 24; ++i){
       activitiesInPlan.put(
           new ActivityDirectiveId(i),
-          new ActivityDirective(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.of(i, Duration.HOURS), serializedDelayDirective, null, true));
     }
     unfinishedActivities.put(
         new ActivityInstanceId(12),

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyPlan.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyPlan.java
@@ -92,8 +92,10 @@ public final class ReadonlyPlan implements Plan {
                                        new DirectiveStart.Absolute(dir.startOffset())
                                      : new DirectiveStart.Anchor(dir.anchorId(), dir.startOffset(), anchorPoint);
 
+                                 var arguments = dir.serializedActivity().getArguments();
                                  return new Directive<A>(
-                                     deserializer.invoke(SerializedValue.of(dir.serializedActivity().getArguments())),
+                                     deserializer.invoke(SerializedValue.of(arguments)),
+                                     () -> new AnyDirective(arguments),
                                      dir.name(),
                                      dirId,
                                      dir.serializedActivity().getTypeName(),
@@ -165,5 +167,10 @@ public final class ReadonlyPlan implements Plan {
   @Override
   public ExternalEvents events() {
     return events(new EventQuery());
+  }
+
+  @Override
+  public @NotNull Directives<?> rawDirectives() {
+    return null;
   }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyProceduralSimResults.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/models/ReadonlyProceduralSimResults.java
@@ -220,4 +220,9 @@ public class ReadonlyProceduralSimResults implements SimulationResults {
   public Directives<AnyDirective> inputDirectives() {
     return plan.directives();
   }
+
+  @Override
+  public @NotNull Directives<?> rawDirectives() {
+    return plan.rawDirectives();
+  }
 }

--- a/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
+++ b/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/PostgresPlanRepository.java
@@ -15,6 +15,7 @@ import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.MissionModelId;
 import gov.nasa.jpl.aerie.types.Plan;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 import gov.nasa.jpl.aerie.types.Timestamp;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -299,7 +300,7 @@ public final class PostgresPlanRepository implements PlanRepository {
     }
   }
 
-  private Map<ActivityDirectiveId, ActivityDirective> getPlanActivities(
+  private Map<ActivityDirectiveId, ActivityDirective<?>> getPlanActivities(
       final Connection connection,
       final PlanId planId
   ) throws SQLException, NoSuchPlanException {
@@ -311,7 +312,7 @@ public final class PostgresPlanRepository implements PlanRepository {
           .stream()
           .collect(Collectors.toMap(
               a -> new ActivityDirectiveId(a.id()),
-              a -> new ActivityDirective(
+              a -> new ActivityDirective<SerializedActivity>(
                   Duration.of(a.startOffsetInMicros(), Duration.MICROSECONDS),
                   a.type(),
                   a.arguments(),

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/mocks/StubPlanService.java
@@ -41,7 +41,7 @@ public final class StubPlanService implements PlanService {
   public static final ActivityDirective EXISTENT_ACTIVITY;
 
   static {
-    EXISTENT_ACTIVITY = new ActivityDirective(
+    EXISTENT_ACTIVITY = new ActivityDirective<?>(
         Duration.ZERO,
         "existent activity",
         Map.of("abc", SerializedValue.of("test-param")),

--- a/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepositoryContractTest.java
+++ b/merlin-server/src/test/java/gov/nasa/jpl/aerie/merlin/server/remotes/PlanRepositoryContractTest.java
@@ -48,7 +48,7 @@ public abstract class PlanRepositoryContractTest {
     // GIVEN
 
     // WHEN
-    final ActivityDirective activity = new ActivityDirective(Duration.ZERO, "abc", Map.of("abc", SerializedValue.of(1)), null, true);
+    final ActivityDirective activity = new ActivityDirective<?>(Duration.ZERO, "abc", Map.of("abc", SerializedValue.of(1)), null, true);
 
     final Plan plan = new Plan("new-plan", new MissionModelId(1), new Timestamp(Instant.now()), new Timestamp(Instant.now()), Map.of());
 

--- a/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/PlanJsonParser.java
+++ b/orchestration-utils/src/main/java/gov/nasa/jpl/aerie/orchestration/PlanJsonParser.java
@@ -11,6 +11,7 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.Plan;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 import gov.nasa.jpl.aerie.types.Timestamp;
 
 import javax.json.Json;
@@ -60,8 +61,8 @@ public class PlanJsonParser {
    *
    * @param activities the json array directives to be parsed
    */
-  private static Map<ActivityDirectiveId, ActivityDirective> parseActivities(final JsonArray activities) {
-    final var activitiesMap = new HashMap<ActivityDirectiveId, ActivityDirective>(activities.size());
+  private static Map<ActivityDirectiveId, ActivityDirective<?>> parseActivities(final JsonArray activities) {
+    final var activitiesMap = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(activities.size());
 
     activities.forEach(v -> {
       final var a = v.asJsonObject();
@@ -76,7 +77,7 @@ public class PlanJsonParser {
 
       activitiesMap.put(
           id,
-          new ActivityDirective(
+          new ActivityDirective<SerializedActivity>(
               startOffset,
               type,
               arguments,

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/Edit.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/Edit.kt
@@ -18,12 +18,12 @@ sealed interface Edit {
   fun inverse(): Edit
 
   /** Create a new activity from a given directive. */
-  data class Create(/***/ val directive: Directive<AnyDirective>): Edit {
+  data class Create(/***/ val directive: Directive<*>): Edit {
     override fun inverse() = Delete(directive)
   }
 
   /** Delete an activity, specified by directive id. */
-  data class Delete(/***/ val directive: Directive<AnyDirective>): Edit {
+  data class Delete(/***/ val directive: Directive<*>): Edit {
     override fun inverse() = Create(directive)
   }
 }

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/EditablePlan.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/EditablePlan.kt
@@ -20,7 +20,7 @@ interface EditablePlan: Plan {
    * @param directive a directive without a directive id.
    * @return a long, the directive id this activity will have.
    */
-  fun create(directive: NewDirective): ActivityDirectiveId
+  fun create(directive: NewDirective<*>): ActivityDirectiveId
 
   /** A simplified version of [create] with minimal arguments. */
   fun create(
@@ -29,6 +29,7 @@ interface EditablePlan: Plan {
       arguments: Map<String, SerializedValue>
   ) = create(NewDirective(
       AnyDirective(arguments),
+      {AnyDirective(arguments)},
       "Unnamed Activity",
       type,
       start

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/NewDirective.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/plan/NewDirective.kt
@@ -5,10 +5,21 @@ import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.Directive
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId
 
+fun NewDirective(inner: AnyDirective, name: String?, type: String, start: DirectiveStart) =
+    NewDirective(
+        inner,
+        { inner },
+        name,
+        type,
+        start
+    )
+
 /** A new directive to be created, which doesn't have an id yet. */
-data class NewDirective(
+data class NewDirective<T: Any>(
     /** The activity's arguments. */
-    val inner: AnyDirective,
+    val inner: T,
+
+    val serializer: () -> AnyDirective,
 
     /** The name of the activity. */
     val name: String?,
@@ -28,8 +39,9 @@ data class NewDirective(
    * @param id The id for the new directive.
    * @param parent The activity this activity is anchored to, if applicable.
    */
-  fun resolve(id: ActivityDirectiveId, parent: Directive<*>?) = Directive(
+  fun resolve(id: ActivityDirectiveId, parent: Directive<*>?) = Directive<T>(
       inner,
+      serializer,
       name,
       id,
       type,

--- a/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/utils/DefaultEditablePlanDriver.kt
+++ b/procedural/scheduling/src/main/kotlin/gov/nasa/ammos/aerie/procedural/scheduling/utils/DefaultEditablePlanDriver.kt
@@ -70,7 +70,7 @@ class DefaultEditablePlanDriver(
      * - the implementor must return the new directive in future calls to [Plan.directives], unless it is later deleted.
      * - the implementor must include the directive in future input plans for simulation, unless it is later deleted.
      */
-    fun create(directive: Directive<AnyDirective>)
+    fun create(directive: Directive<*>)
 
     /**
      * Remove a directive from the plan, specified by ID.
@@ -107,7 +107,7 @@ class DefaultEditablePlanDriver(
      * add additional checks by overriding this method and calling `super.validate(directive)`. Implementor
      * should throw if the directive is invalid.
      */
-    fun validate(directive: Directive<AnyDirective>) {
+    fun validate(directive: Directive<*>) {
       if (directive.startTime > duration()) {
         throw Exception("New activity with id ${directive.id.id()} would start after the end of the plan")
       }
@@ -163,7 +163,7 @@ class DefaultEditablePlanDriver(
     return internalResults
   }
 
-  override fun create(directive: NewDirective): ActivityDirectiveId {
+  override fun create(directive: NewDirective<*>): ActivityDirectiveId {
     class ParentSearchException(id: ActivityDirectiveId, size: Int): Exception("Expected one parent activity with id $id, found $size")
     val id = adapter.generateDirectiveId()
     val parent = when (val s = directive.start) {

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/payloads/activities/Directive.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/payloads/activities/Directive.kt
@@ -9,6 +9,8 @@ data class Directive<A: Any>(
   /** The inner payload, typically either [AnyDirective] or a mission model activity type. */
   @JvmField val inner: A,
 
+  val serializer: () -> AnyDirective,
+
   /** The name of this specific directive. */
   @JvmField val name: String?,
 
@@ -30,16 +32,19 @@ data class Directive<A: Any>(
     get() = Interval.at(startTime)
 
   override fun withNewInterval(i: Interval): Directive<A> {
-    if (i.isPoint()) return Directive(inner, name, id, type, start.atNewTime(i.start))
+    if (i.isPoint()) return Directive(inner, serializer, name, id, type, start.atNewTime(i.start))
     else throw Exception("Cannot change directive time to a non-instantaneous interval.")
   }
 
-  /** Transform the inner payload with a function, returning a new directive object. */
-  fun <R: Any> mapInner(/***/ f: (A) -> R) = Directive(
-    f(inner),
-    name,
-    id,
-    type,
-    start
-  )
+  fun anyDirective() = serializer()
+
+//  /** Transform the inner payload with a function, returning a new directive object. */
+//  fun <R: Any> mapInner(/***/ f: (A) -> R) = Directive(
+//    f(inner),
+//      serializer,
+//    name,
+//    id,
+//    type,
+//    start
+//  )
 }

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/Plan.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/Plan.kt
@@ -35,6 +35,8 @@ interface Plan {
   /** Queries all activity directives, deserializing them as [AnyDirective]. **/
   fun directives() = directives(null, AnyDirective.deserializer())
 
+  fun rawDirectives(): Directives<*>
+
   /**
    * Query a resource profile from the external datasets associated with this plan.
    *

--- a/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/SimulationResults.kt
+++ b/procedural/timeline/src/main/kotlin/gov/nasa/ammos/aerie/procedural/timeline/plan/SimulationResults.kt
@@ -85,4 +85,6 @@ interface SimulationResults {
   fun <A: Any> inputDirectives(deserializer: (SerializedValue) -> A): Directives<A>
   /** The input directives that were used for this simulation, deserialized as [AnyDirective]. */
   fun inputDirectives() = inputDirectives(AnyDirective.deserializer())
+
+  fun rawDirectives(): Directives<*>
 }

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/StubPlan.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/StubPlan.java
@@ -65,4 +65,10 @@ public class StubPlan implements Plan {
   public ExternalEvents events(@NotNull final EventQuery query) {
     throw new NotImplementedError();
   }
+
+  @Override
+  @NotNull
+  public Directives<?> rawDirectives() {
+    throw new NotImplementedError();
+  }
 }

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/StubSimulationResults.kt
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/StubSimulationResults.kt
@@ -23,4 +23,7 @@ open class StubSimulationResults: SimulationResults {
   ): TL = TODO()
   override fun <A : Any> instances(type: String?, deserializer: (SerializedValue) -> A): Instances<A> = TODO()
   override fun <A : Any> inputDirectives(deserializer: (SerializedValue) -> A): Directives<A> = TODO()
+    override fun rawDirectives(): Directives<*> {
+        TODO("Not yet implemented")
+    }
 }

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
@@ -126,7 +126,7 @@ public class TypeUtilsEditablePlanAdapter implements gov.nasa.ammos.aerie.proced
               case DirectiveStart.Absolute a -> a.getTime();
               default -> throw new Error("unreachable");
             },
-            activity,
+            activity.inner,
             () -> new SerializedActivity(activity.getType(), Map.copyOf(activity.getSerializer().invoke().arguments)),
             switch (activity.getStart()) {
               case DirectiveStart.Anchor a -> a.getParentId();

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
@@ -22,6 +22,7 @@ import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveSta
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.Plan;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 import kotlin.jvm.functions.Function1;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -117,8 +118,8 @@ public class TypeUtilsEditablePlanAdapter implements gov.nasa.ammos.aerie.proced
     }
   }
 
-  private static ActivityDirective toTypeUtilsActivity(Directive<AnyDirective> activity) {
-    return new ActivityDirective(
+  private static ActivityDirective<?> toTypeUtilsActivity(Directive<AnyDirective> activity) {
+    return new ActivityDirective<>(
             switch (activity.getStart()) {
               case DirectiveStart.Anchor a -> a.getOffset();
               case DirectiveStart.Absolute a -> a.getTime();
@@ -182,5 +183,11 @@ public class TypeUtilsEditablePlanAdapter implements gov.nasa.ammos.aerie.proced
   @Override
   public ExternalEvents events(@NotNull EventQuery query) {
     return plan.events(query);
+  }
+
+  @Override
+  @NotNull
+  public Directives<?> rawDirectives() {
+    return plan.rawDirectives();
   }
 }

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsEditablePlanAdapter.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -92,7 +93,7 @@ public class TypeUtilsEditablePlanAdapter implements gov.nasa.ammos.aerie.proced
   }
 
   @Override
-  public void create(@NotNull Directive<AnyDirective> directive) {
+  public void create(@NotNull Directive<?> directive) {
     changedSinceLastSim = true;
     plan.plan().activityDirectives().put(directive.id, toTypeUtilsActivity(directive));
   }
@@ -118,15 +119,15 @@ public class TypeUtilsEditablePlanAdapter implements gov.nasa.ammos.aerie.proced
     }
   }
 
-  private static ActivityDirective<?> toTypeUtilsActivity(Directive<AnyDirective> activity) {
+  private static ActivityDirective<?> toTypeUtilsActivity(Directive<?> activity) {
     return new ActivityDirective<>(
             switch (activity.getStart()) {
               case DirectiveStart.Anchor a -> a.getOffset();
               case DirectiveStart.Absolute a -> a.getTime();
               default -> throw new Error("unreachable");
             },
-            activity.getType(),
-            activity.inner.arguments,
+            activity,
+            () -> new SerializedActivity(activity.getType(), Map.copyOf(activity.getSerializer().invoke().arguments)),
             switch (activity.getStart()) {
               case DirectiveStart.Anchor a -> a.getParentId();
               case DirectiveStart.Absolute ignored -> null;

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
@@ -105,7 +105,8 @@ public record TypeUtilsPlanAdapter(Plan plan) implements gov.nasa.ammos.aerie.pr
     return new Directives<>(plan.activityDirectives().entrySet().stream().map($ -> {
       ActivityDirective<?> act = $.getValue();
       return new Directive<>(
-          act, () -> new AnyDirective(act.serializedActivity().getArguments()), act.name(), $.getKey(), act.serializedActivity().getTypeName(), act.anchorId() == null
+          act.thing(),
+          () -> new AnyDirective(act.serializedActivity().getArguments()), act.name(), $.getKey(), act.serializedActivity().getTypeName(), act.anchorId() == null
           ? new DirectiveStart.Absolute(act.startOffset())
           : new DirectiveStart.Anchor(
           act.anchorId(),

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
@@ -51,7 +51,7 @@ public record TypeUtilsPlanAdapter(Plan plan) implements gov.nasa.ammos.aerie.pr
       String type,
       @NotNull Function1<? super SerializedValue, ? extends A> deserializer)
   {
-    final Stream<Map.Entry<ActivityDirectiveId, ActivityDirective>> activities;
+    final Stream<Map.Entry<ActivityDirectiveId, ActivityDirective<?>>> activities;
     if (type == null) {
       activities = plan.activityDirectives().entrySet().stream();
     } else {
@@ -61,9 +61,10 @@ public record TypeUtilsPlanAdapter(Plan plan) implements gov.nasa.ammos.aerie.pr
 
     final List<Directive<A>> result = activities.map($ -> {
       final var id = $.getKey();
-      final var act = $.getValue();
+      final ActivityDirective<?> act = $.getValue();
       return new Directive<>(
           (A) deserializer.invoke(SerializedValue.of(act.serializedActivity().getArguments())),
+          null, // TODO
           act.name(),
           id,
           act.serializedActivity().getTypeName(),
@@ -95,5 +96,11 @@ public record TypeUtilsPlanAdapter(Plan plan) implements gov.nasa.ammos.aerie.pr
   @Override
   public ExternalEvents events(@NotNull final EventQuery query) {
     throw new NotImplementedException();
+  }
+
+  @Override
+  @NotNull
+  public Directives<?> rawDirectives() {
+    return new Directives<>(plan.activityDirectives().values().stream().map($ -> $).toList());
   }
 }

--- a/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
+++ b/procedural/utils/src/main/java/gov/nasa/ammos/aerie/procedural/utils/TypeUtilsPlanAdapter.java
@@ -5,6 +5,7 @@ import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives;
 import gov.nasa.ammos.aerie.procedural.timeline.collections.ExternalEvents;
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment;
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyDirective;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.Directive;
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart;
 import gov.nasa.ammos.aerie.procedural.timeline.plan.EventQuery;
@@ -101,6 +102,18 @@ public record TypeUtilsPlanAdapter(Plan plan) implements gov.nasa.ammos.aerie.pr
   @Override
   @NotNull
   public Directives<?> rawDirectives() {
-    return new Directives<>(plan.activityDirectives().values().stream().map($ -> $).toList());
+    return new Directives<>(plan.activityDirectives().entrySet().stream().map($ -> {
+      ActivityDirective<?> act = $.getValue();
+      return new Directive<>(
+          act, () -> new AnyDirective(act.serializedActivity().getArguments()), act.name(), $.getKey(), act.serializedActivity().getTypeName(), act.anchorId() == null
+          ? new DirectiveStart.Absolute(act.startOffset())
+          : new DirectiveStart.Anchor(
+          act.anchorId(),
+          act.startOffset(),
+          act.anchoredToStart()
+              ? DirectiveStart.Anchor.AnchorPoint.Start
+              : DirectiveStart.Anchor.AnchorPoint.End
+      ));
+    }).toList());
   }
 }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulePlanGrounder.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulePlanGrounder.java
@@ -6,10 +6,13 @@ import gov.nasa.jpl.aerie.merlin.driver.StartOffsetReducer;
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -31,11 +34,11 @@ public class SchedulePlanGrounder {
         .stream().map(ActivityDirectiveId::id)
         .max(Long::compare);
 
-    final var converted = schedulingActivityList
+    final Map<ActivityDirectiveId, ActivityDirective<?>> converted = schedulingActivityList
         .stream()
         .map(a -> Pair.of(
             a.id(),
-            new ActivityDirective(
+            new ActivityDirective<>(
                 a.startOffset(),
                 a.type().getName(),
                 a.arguments(),

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulingActivity.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/model/SchedulingActivity.java
@@ -143,7 +143,7 @@ public record SchedulingActivity(
     );
   }
 
-  public static SchedulingActivity fromExistingActivityDirective(ActivityDirectiveId id, ActivityDirective activity, ActivityType type, Duration duration){
+  public static SchedulingActivity fromExistingActivityDirective(ActivityDirectiveId id, ActivityDirective<?> activity, ActivityType type, Duration duration){
     return new SchedulingActivity(
         id,
         type,

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/CheckpointSimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/CheckpointSimulationFacade.java
@@ -16,6 +16,7 @@ import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivity;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
 import gov.nasa.jpl.aerie.types.MissionModelId;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,6 @@ import java.util.function.Supplier;
 
 import static gov.nasa.jpl.aerie.merlin.driver.CheckpointSimulationDriver.onceAllActivitiesAreFinished;
 import static gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacadeUtils.scheduleFromPlan;
-import static gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacadeUtils.schedulingActToActivityDir;
 import static gov.nasa.jpl.aerie.scheduler.simulation.SimulationFacadeUtils.updatePlanWithChildActivities;
 
 public class CheckpointSimulationFacade implements SimulationFacade {
@@ -121,9 +121,10 @@ public class CheckpointSimulationFacade implements SimulationFacade {
       //replace the anchor ids in the plan
       for (final var act : planSimCorrespondence.directiveIdActivityDirectiveMap().entrySet()) {
         if (act.getValue().anchorId() != null && act.getValue().anchorId().equals(replacements.getKey())) {
-          final var replacementActivity = new ActivityDirective(
+          final var replacementActivity = new ActivityDirective<>(
               act.getValue().startOffset(),
-              act.getValue().serializedActivity(),
+              act.getValue().thing(),
+              act.getValue().thunk(),
               replacements.getValue(),
               act.getValue().anchoredToStart(),
               act.getValue().name());

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacade.java
@@ -8,6 +8,7 @@ import gov.nasa.jpl.aerie.scheduler.model.Plan;
 import gov.nasa.jpl.aerie.scheduler.model.SchedulingActivity;
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -61,12 +62,12 @@ public interface SimulationFacade {
   ) {}
 
   record PlanSimCorrespondence(
-      Map<ActivityDirectiveId, ActivityDirective> directiveIdActivityDirectiveMap){
+      Map<ActivityDirectiveId, ActivityDirective<?>> directiveIdActivityDirectiveMap){
     @Override
     public boolean equals(Object other){
       if(other instanceof PlanSimCorrespondence planSimCorrespondenceAs){
         return directiveIdActivityDirectiveMap.size() == planSimCorrespondenceAs.directiveIdActivityDirectiveMap.size() &&
-               new HashSet<>(directiveIdActivityDirectiveMap.values()).containsAll(new HashSet<>(((PlanSimCorrespondence) other).directiveIdActivityDirectiveMap.values()));
+               new HashSet<>(directiveIdActivityDirectiveMap.values()).containsAll(new HashSet<>(planSimCorrespondenceAs.directiveIdActivityDirectiveMap.values()));
       }
       return false;
     }

--- a/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacadeUtils.java
+++ b/scheduler-driver/src/main/java/gov/nasa/jpl/aerie/scheduler/simulation/SimulationFacadeUtils.java
@@ -30,7 +30,7 @@ public class SimulationFacadeUtils {
     if(activities.isEmpty()) return new SimulationFacade.PlanSimCorrespondence(Map.of());
     //filter out child activities
     final var activitiesWithoutParent = activities.stream().filter(a -> a.topParent() == null).toList();
-    final Map<ActivityDirectiveId, ActivityDirective> directivesToSimulate = new HashMap<>();
+    final Map<ActivityDirectiveId, ActivityDirective<?>> directivesToSimulate = new HashMap<>();
 
     for(final var activity : activitiesWithoutParent) {
       final var activityDirective = schedulingActToActivityDir(activity, schedulerModel);
@@ -154,9 +154,10 @@ public class SimulationFacadeUtils {
       }
     }
     final var serializedActivity = new SerializedActivity(activity.getType().getName(), arguments);
-    return new ActivityDirective(
+    return new ActivityDirective<SerializedActivity>(
         activity.startOffset(),
         serializedActivity,
+        () -> serializedActivity,
         activity.anchorId(),
         activity.anchoredToStart(),
         activity.name());

--- a/scheduler-driver/src/main/kotlin/gov/nasa/jpl/aerie/scheduler/plan/MerlinToProcedureSimulationResultsAdapter.kt
+++ b/scheduler-driver/src/main/kotlin/gov/nasa/jpl/aerie/scheduler/plan/MerlinToProcedureSimulationResultsAdapter.kt
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.plan
 
 import gov.nasa.ammos.aerie.procedural.scheduling.utils.PerishableSimulationResults
 import gov.nasa.ammos.aerie.procedural.timeline.Interval
+import gov.nasa.ammos.aerie.procedural.timeline.collections.Directives
 import gov.nasa.ammos.aerie.procedural.timeline.collections.Instances
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
@@ -153,4 +154,5 @@ open class MerlinToProcedureSimulationResultsAdapter(
   }
 
   override fun <A : Any> inputDirectives(deserializer: (SerializedValue) -> A) = plan.directives(null, deserializer)
+    override fun rawDirectives(): Directives<*> = plan.rawDirectives()
 }

--- a/scheduler-driver/src/main/kotlin/gov/nasa/jpl/aerie/scheduler/plan/SchedulerPlanEditAdapter.kt
+++ b/scheduler-driver/src/main/kotlin/gov/nasa/jpl/aerie/scheduler/plan/SchedulerPlanEditAdapter.kt
@@ -34,7 +34,7 @@ data class SchedulerPlanEditAdapter(
     return MerlinToProcedureSimulationResultsAdapter(merlinResults.driverResults, plan.copy(schedulerPlan = plan.duplicate()))
   }
 
-  override fun create(directive: Directive<AnyDirective>) {
+  override fun create(directive: Directive<*>) {
     plan.add(directive.toSchedulingActivity(lookupActivityType))
   }
 
@@ -46,13 +46,13 @@ data class SchedulerPlanEditAdapter(
     simulationFacade.simulateWithResults(plan, options.pause.resolve(this))
   }
 
-  override fun validate(directive: Directive<AnyDirective>) {
+  override fun validate(directive: Directive<*>) {
     super.validate(directive)
-    lookupActivityType(directive.type).specType.inputType.validateArguments(directive.inner.arguments)
+    lookupActivityType(directive.type).specType.inputType.validateArguments(directive.anyDirective().arguments)
   }
 
   companion object {
-    @JvmStatic fun Directive<AnyDirective>.toSchedulingActivity(lookupActivityType: (String) -> ActivityType) = SchedulingActivity(
+    @JvmStatic fun Directive<*>.toSchedulingActivity(lookupActivityType: (String) -> ActivityType) = SchedulingActivity(
         id,
         lookupActivityType(type),
         when (val s = start) {
@@ -61,17 +61,17 @@ data class SchedulerPlanEditAdapter(
         },
         when (val d = lookupActivityType(type).durationType) {
           is DurationType.Controllable -> {
-            inner.arguments[d.parameterName]?.asInt()?.let { Duration(it.get()) }
+            anyDirective().arguments[d.parameterName]?.asInt()?.let { Duration(it.get()) }
           }
           is DurationType.Parametric -> {
-            d.durationFunction.apply(inner.arguments)
+            d.durationFunction.apply(anyDirective().arguments)
           }
           is DurationType.Fixed -> {
             d.duration
           }
           else -> Duration.ZERO
         },
-        inner.arguments,
+        anyDirective().arguments,
         null,
         when (val s = start) {
           is DirectiveStart.Absolute -> null

--- a/scheduler-driver/src/main/kotlin/gov/nasa/jpl/aerie/scheduler/plan/SchedulerToProcedurePlanAdapter.kt
+++ b/scheduler-driver/src/main/kotlin/gov/nasa/jpl/aerie/scheduler/plan/SchedulerToProcedurePlanAdapter.kt
@@ -6,6 +6,7 @@ import gov.nasa.ammos.aerie.procedural.timeline.collections.ExternalEvents
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.ExternalEvent
 import gov.nasa.ammos.aerie.procedural.timeline.ops.SerialSegmentOps
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.Segment
+import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.AnyDirective
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.Directive
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart
 import gov.nasa.ammos.aerie.procedural.timeline.payloads.activities.DirectiveStart.Anchor.AnchorPoint.Companion.anchorToStart
@@ -14,7 +15,6 @@ import gov.nasa.ammos.aerie.procedural.timeline.util.duration.minus
 import gov.nasa.ammos.aerie.procedural.timeline.util.duration.plus
 import gov.nasa.jpl.aerie.constraints.model.DiscreteProfile
 import gov.nasa.jpl.aerie.constraints.model.LinearProfile
-import gov.nasa.jpl.aerie.constraints.time.Interval as ConstraintsInterval
 import gov.nasa.jpl.aerie.constraints.time.Segment as ConstraintsSegment
 import gov.nasa.jpl.aerie.merlin.protocol.types.Duration
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue
@@ -45,9 +45,10 @@ data class SchedulerToProcedurePlanAdapter(
 
     val result = ArrayList<Directive<A>>(schedulerActivities.size)
     for (activity in schedulerActivities) {
-      result.add(
+        result.add(
           Directive(
               deserializer(SerializedValue.of(activity.arguments)),
+              { AnyDirective(activity.arguments) },
               activity.name,
               activity.id,
               activity.type.name,
@@ -59,7 +60,11 @@ data class SchedulerToProcedurePlanAdapter(
     return Directives(result)
   }
 
-  override fun events(query: EventQuery): ExternalEvents {
+    override fun rawDirectives(): Directives<*> {
+        TODO("Not yet implemented")
+    }
+
+    override fun events(query: EventQuery): ExternalEvents {
     var result = if (query.derivationGroups != null) query.derivationGroups!!.flatMap {
       eventsByDerivationGroup[it]
         ?: throw Error("derivation group either doesn't exist or isn't associated with plan: $it")

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/AnchorSchedulerTest.java
@@ -61,7 +61,7 @@ public class AnchorSchedulerTest {
     private final Instant planStart = Instant.EPOCH;
 
 
-    public SimulationResultsComputerInputs simulateActivities( final Map<ActivityDirectiveId, ActivityDirective> schedule){
+    public SimulationResultsComputerInputs simulateActivities( final Map<ActivityDirectiveId, ActivityDirective<?>> schedule){
       return CheckpointSimulationDriver.simulateWithCheckpoints(
           AnchorTestModel,
           schedule,
@@ -105,13 +105,13 @@ public class AnchorSchedulerTest {
       }
     }
 
-    private void constructFullComplete5AryTree(int maxLevel, int currentLevel, long parentNode, Map<ActivityDirectiveId, ActivityDirective> activitiesToSimulate, Map<ActivityInstanceId, ActivityInstance> simulatedActivities){
+    private void constructFullComplete5AryTree(int maxLevel, int currentLevel, long parentNode, Map<ActivityDirectiveId, ActivityDirective<?>> activitiesToSimulate, Map<ActivityInstanceId, ActivityInstance> simulatedActivities){
       if(currentLevel > maxLevel) return;
       for(int i = 1; i <= 5; i++) {
         long curElement = parentNode*5+i;
         activitiesToSimulate.put(
             new ActivityDirectiveId(curElement),
-            new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(parentNode), false));
+            new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(parentNode), false));
         simulatedActivities.put(
             new ActivityInstanceId(curElement),
             new ActivityInstance(
@@ -140,7 +140,7 @@ public class AnchorSchedulerTest {
     @DisplayName("Activities depending on no activities simulate at the correct time")
     public void activitiesAnchoredToPlan() {
       final var minusOneMinute = Duration.of(-60, Duration.SECONDS);
-      final var resolveToPlanStartAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(415);
+      final var resolveToPlanStartAnchors = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(415);
       final Map<ActivityInstanceId, ActivityInstance> simulatedActivities = new HashMap<>(415);
 
       // Anchored to Plan Start (only positive is allowed)
@@ -148,7 +148,7 @@ public class AnchorSchedulerTest {
         final var activityDirectiveId = new ActivityDirectiveId(l);
         resolveToPlanStartAnchors.put(
             activityDirectiveId,
-            new ActivityDirective(Duration.of(l, Duration.SECONDS), serializedDelayDirective, null, true));
+            new ActivityDirective<?>(Duration.of(l, Duration.SECONDS), serializedDelayDirective, null, true));
         simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
             serializedDelayDirective.getTypeName(),
             Map.of(),
@@ -165,7 +165,7 @@ public class AnchorSchedulerTest {
         final var activityDirectiveId = new ActivityDirectiveId(l);
         resolveToPlanStartAnchors.put(
             activityDirectiveId,
-            new ActivityDirective(Duration.of(-l, Duration.MINUTES), serializedDelayDirective, null, false)); // Minutes so they finish by simulation end
+            new ActivityDirective<?>(Duration.of(-l, Duration.MINUTES), serializedDelayDirective, null, false)); // Minutes so they finish by simulation end
         simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
             serializedDelayDirective.getTypeName(),
             Map.of(),
@@ -181,7 +181,7 @@ public class AnchorSchedulerTest {
       // Chained to plan start
       resolveToPlanStartAnchors.put(
           new ActivityDirectiveId(15),
-          new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(0), true));
+          new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(0), true));
       simulatedActivities.put(new ActivityInstanceId(15), new ActivityInstance(
           serializedDelayDirective.getTypeName(),
           Map.of(),
@@ -198,7 +198,7 @@ public class AnchorSchedulerTest {
         if ((l & 1) == 0) { // If even
           resolveToPlanStartAnchors.put(
               activityDirectiveId,
-              new ActivityDirective(oneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
+              new ActivityDirective<?>(oneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
           simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
               serializedDelayDirective.getTypeName(),
               Map.of(),
@@ -212,7 +212,7 @@ public class AnchorSchedulerTest {
         } else {
           resolveToPlanStartAnchors.put(
               activityDirectiveId,
-              new ActivityDirective(minusOneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
+              new ActivityDirective<?>(minusOneMinute, serializedDelayDirective, new ActivityDirectiveId(l - 1), true));
           simulatedActivities.put(new ActivityInstanceId(l), new ActivityInstance(
               serializedDelayDirective.getTypeName(),
               Map.of(),
@@ -246,17 +246,17 @@ public class AnchorSchedulerTest {
     @Test
     @DisplayName("Activities depending on another activities simulate at the correct time")
     public void activitiesAnchoredToOtherActivities() {
-      final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
-      final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective>(400);
+      final var allEndTimeAnchors = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
+      final var endTimeAnchorEveryFifth = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(400);
       final Map<ActivityInstanceId, ActivityInstance> simulatedActivities = new HashMap<>(800);
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(800);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(800);
 
       allEndTimeAnchors.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(oneMinute, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(oneMinute, serializedDelayDirective, null, true));
       endTimeAnchorEveryFifth.put(
           new ActivityDirectiveId(400),
-          new ActivityDirective(oneMinute, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(oneMinute, serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(0),
           new ActivityInstance(
@@ -286,7 +286,7 @@ public class AnchorSchedulerTest {
 
         allEndTimeAnchors.put(
             activityDirectiveIdAETA,
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 oneMinute,
                 serializedDelayDirective,
                 new ActivityDirectiveId(l - 1),
@@ -306,7 +306,7 @@ public class AnchorSchedulerTest {
         if (k % 5 == 0) {
           endTimeAnchorEveryFifth.put(
               activityDirectiveIdEveryFifth,
-              new ActivityDirective(
+              new ActivityDirective<?>(
                   oneMinute,
                   serializedDelayDirective,
                   new ActivityDirectiveId(k - 1),
@@ -315,7 +315,7 @@ public class AnchorSchedulerTest {
         } else {
           endTimeAnchorEveryFifth.put(
               activityDirectiveIdEveryFifth,
-              new ActivityDirective(
+              new ActivityDirective<?>(
                   oneMinute,
                   serializedDelayDirective,
                   new ActivityDirectiveId(k - 1),
@@ -357,13 +357,13 @@ public class AnchorSchedulerTest {
     @Test
     @DisplayName("Reference to anchored activities are correctly maintained by the driver")
     public void activitiesAnchoredToOtherActivitiesSimple() {
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(2);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(2);
       activitiesToSimulate.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(oneMinute, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(oneMinute, serializedDelayDirective, null, true));
       activitiesToSimulate.put(
           new ActivityDirectiveId(1),
-          new ActivityDirective(oneMinute, serializedDelayDirective, new ActivityDirectiveId(0), false));
+          new ActivityDirective<?>(oneMinute, serializedDelayDirective, new ActivityDirectiveId(0), false));
       final var simulationResults = simulateActivities(activitiesToSimulate);
       final var durationOfAnchoredActivity = SimulationFacadeUtils.getActivityDuration(new ActivityDirectiveId(1), simulationResults);
       assertTrue(durationOfAnchoredActivity.isPresent());
@@ -377,16 +377,16 @@ public class AnchorSchedulerTest {
       // and two NDs cannot be adjacent to each other, there are 20 permutations.
 
       // In order to have fewer activities and more complex subtrees, the first and second elements of a set of sequences will be reused when possible
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(23);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(23);
       // NOTE: This list is intentionally keyed on ActivityDirectiveId, not on SimulatedActivityId.
       // Additionally, because we do not know the order the child activities will generate in, DecompositionDirectives will have a List.of() rather than the correct value
       final var topLevelSimulatedActivities = new HashMap<ActivityDirectiveId, ActivityInstance>(23);
       final var threeMinutes = Duration.of(3, Duration.MINUTES);
 
       // ND <-s- D <-s- D
-      activitiesToSimulate.put(new ActivityDirectiveId(1), new ActivityDirective(Duration.ZERO, serializedDelayDirective, null, true));
-      activitiesToSimulate.put(new ActivityDirectiveId(2), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(1), true));
-      activitiesToSimulate.put(new ActivityDirectiveId(3), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(2), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(1), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, null, true));
+      activitiesToSimulate.put(new ActivityDirectiveId(2), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(1), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(3), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(2), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(1),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH, oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(1)), computedAttributes));
@@ -398,26 +398,26 @@ public class AnchorSchedulerTest {
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH, threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(3)), computedAttributes));
 
       // ND <-s- D <-e- D
-      activitiesToSimulate.put(new ActivityDirectiveId(4), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(2), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(4), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(2), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(4),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(4)), computedAttributes));
 
       // ND <-s- D <-s- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(5), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(2), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(5), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(2), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(5),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH, oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(5)), computedAttributes));
 
       // ND <-s- D <-e- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(6), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(2), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(6), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(2), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(6),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(6)), computedAttributes));
 
       // ND <-e- D <-s- D
-      activitiesToSimulate.put(new ActivityDirectiveId(7), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(1), false));
-      activitiesToSimulate.put(new ActivityDirectiveId(8), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(7), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(7), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(1), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(8), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(7), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(7),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(1, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(7)), computedAttributes));
@@ -426,91 +426,91 @@ public class AnchorSchedulerTest {
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(1, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(8)), computedAttributes));
 
       // ND <-e- D <-e- D
-      activitiesToSimulate.put(new ActivityDirectiveId(9), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(7), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(9), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(7), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(9),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(4, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(9)), computedAttributes));
 
       // ND <-e- D <-s- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(10), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(7), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(10), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(7), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(10),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(1, ChronoUnit.MINUTES), oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(10)), computedAttributes));
 
       // ND <-e- D <-e- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(11), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(7), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(11), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(7), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(11),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(4, ChronoUnit.MINUTES), oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(11)), computedAttributes));
 
       // D <-s- D <-s- D
-      activitiesToSimulate.put(new ActivityDirectiveId(12), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(3), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(12), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(3), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(12),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH, threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(12)), computedAttributes));
 
       // D <-s- D <-e- D
-      activitiesToSimulate.put(new ActivityDirectiveId(13), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(3), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(13), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(3), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(13),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(13)), computedAttributes));
 
       // D <-s- D <-s- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(14), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(3), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(14), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(3), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(14),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH, oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(14)), computedAttributes));
 
       // D <-s- D <-e- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(15), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(3), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(15), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(3), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(15),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(15)), computedAttributes));
 
       // D <-e- D <-s- D
-      activitiesToSimulate.put(new ActivityDirectiveId(16), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(4), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(16), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(4), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(16),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(16)), computedAttributes));
 
       // D <-e- D <-e- D
-      activitiesToSimulate.put(new ActivityDirectiveId(17), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(4), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(17), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(4), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(17),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(6, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(17)), computedAttributes));
 
       // D <-e- D <-s- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(18), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(4), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(18), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(4), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(18),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(18)), computedAttributes));
 
       // D <-e- D <-e- ND
-      activitiesToSimulate.put(new ActivityDirectiveId(19), new ActivityDirective(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(4), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(19), new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, new ActivityDirectiveId(4), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(19),
           new ActivityInstance(serializedDelayDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(6, ChronoUnit.MINUTES), oneMinute, null, List.of(), Optional.of(new ActivityDirectiveId(19)), computedAttributes));
 
       // D <-s- ND <-s- D
-      activitiesToSimulate.put(new ActivityDirectiveId(20), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(14), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(20), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(14), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(20),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH, threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(20)), computedAttributes));
 
       // D <-s- ND <-e- D
-      activitiesToSimulate.put(new ActivityDirectiveId(21), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(14), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(21), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(14), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(21),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(1, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(21)), computedAttributes));
 
       // D <-e- ND <-s- D
-      activitiesToSimulate.put(new ActivityDirectiveId(22), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(15), true));
+      activitiesToSimulate.put(new ActivityDirectiveId(22), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(15), true));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(22),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(3, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(22)), computedAttributes));
 
       // D <-e- ND <-e- D
-      activitiesToSimulate.put(new ActivityDirectiveId(23), new ActivityDirective(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(15), false));
+      activitiesToSimulate.put(new ActivityDirectiveId(23), new ActivityDirective<?>(Duration.ZERO, serializedDecompositionDirective, new ActivityDirectiveId(15), false));
       topLevelSimulatedActivities.put(
           new ActivityDirectiveId(23),
           new ActivityInstance(serializedDecompositionDirective.getTypeName(), Map.of(), Instant.EPOCH.plus(4, ChronoUnit.MINUTES), threeMinutes, null, List.of(), Optional.of(new ActivityDirectiveId(23)), computedAttributes));
@@ -615,12 +615,12 @@ public class AnchorSchedulerTest {
       // Full and complete 5-ary tree,  6 levels deep
       // Number of activity directives = 5^0 + 5^1 + 5^2 + 5^3 + 5^4 + 5^5 = 3906
 
-      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective>(3906);
+      final var activitiesToSimulate = new HashMap<ActivityDirectiveId, ActivityDirective<?>>(3906);
       final var simulatedActivities = new HashMap<ActivityInstanceId, ActivityInstance>(3906);
 
       activitiesToSimulate.put(
           new ActivityDirectiveId(0),
-          new ActivityDirective(Duration.ZERO, serializedDelayDirective, null, true));
+          new ActivityDirective<?>(Duration.ZERO, serializedDelayDirective, null, true));
       simulatedActivities.put(
           new ActivityInstanceId(0),
           new ActivityInstance(

--- a/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/InMemoryCachedEngineStoreTest.java
+++ b/scheduler-driver/src/test/java/gov/nasa/jpl/aerie/scheduler/simulation/InMemoryCachedEngineStoreTest.java
@@ -39,8 +39,8 @@ public class InMemoryCachedEngineStoreTest {
     return new CachedSimulationEngine(
         Duration.SECOND,
         Map.of(
-            new ActivityDirectiveId(1), new ActivityDirective(Duration.HOUR, "ActivityType1", Map.of(), null, true),
-            new ActivityDirectiveId(2), new ActivityDirective(Duration.HOUR, "ActivityType2", Map.of(), null, true)
+            new ActivityDirectiveId(1), new ActivityDirective<?>(Duration.HOUR, "ActivityType1", Map.of(), null, true),
+            new ActivityDirectiveId(2), new ActivityDirective<?>(Duration.HOUR, "ActivityType2", Map.of(), null, true)
         ),
         new SimulationEngine(SimulationUtility.getFooMissionModel().getInitialCells()),
         null,
@@ -53,8 +53,8 @@ public class InMemoryCachedEngineStoreTest {
     return new CachedSimulationEngine(
         Duration.SECOND,
         Map.of(
-            new ActivityDirectiveId(3), new ActivityDirective(Duration.HOUR, "ActivityType3", Map.of(), null, true),
-            new ActivityDirectiveId(4), new ActivityDirective(Duration.HOUR, "ActivityType4", Map.of(), null, true)
+            new ActivityDirectiveId(3), new ActivityDirective<?>(Duration.HOUR, "ActivityType3", Map.of(), null, true),
+            new ActivityDirectiveId(4), new ActivityDirective<?>(Duration.HOUR, "ActivityType4", Map.of(), null, true)
         ),
         new SimulationEngine(SimulationUtility.getFooMissionModel().getInitialCells()),
         null,
@@ -67,8 +67,8 @@ public class InMemoryCachedEngineStoreTest {
     return new CachedSimulationEngine(
         Duration.SECOND,
         Map.of(
-            new ActivityDirectiveId(5), new ActivityDirective(Duration.HOUR, "ActivityType5", Map.of(), null, true),
-            new ActivityDirectiveId(6), new ActivityDirective(Duration.HOUR, "ActivityType6", Map.of(), null, true)
+            new ActivityDirectiveId(5), new ActivityDirective<?>(Duration.HOUR, "ActivityType5", Map.of(), null, true),
+            new ActivityDirectiveId(6), new ActivityDirective<?>(Duration.HOUR, "ActivityType6", Map.of(), null, true)
         ),
         new SimulationEngine(SimulationUtility.getFooMissionModel().getInitialCells()),
         null,

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/MerlinPlan.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/models/MerlinPlan.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerie.scheduler.server.models;
 
 import gov.nasa.jpl.aerie.types.ActivityDirective;
 import gov.nasa.jpl.aerie.types.ActivityDirectiveId;
+import gov.nasa.jpl.aerie.types.SerializedActivity;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -10,7 +11,7 @@ import java.util.Optional;
 
 public class MerlinPlan {
 
-  private final Map<ActivityDirectiveId, ActivityDirective> activities;
+  private final Map<ActivityDirectiveId, ActivityDirective<?>> activities;
 
   public MerlinPlan(){
     activities = new HashMap<>();
@@ -23,11 +24,11 @@ public class MerlinPlan {
     activities.put(id, activity);
   }
 
-  public Map<ActivityDirectiveId, ActivityDirective> getActivitiesById(){
+  public Map<ActivityDirectiveId, ActivityDirective<?>> getActivitiesById(){
     return Collections.unmodifiableMap(activities);
   }
 
-  public Optional<ActivityDirective> getActivityById(final ActivityDirectiveId id){
+  public Optional<ActivityDirective<?>> getActivityById(final ActivityDirectiveId id){
     return Optional.ofNullable(activities.get(id));
   }
 

--- a/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinDatabaseService.java
+++ b/scheduler-server/src/main/java/gov/nasa/jpl/aerie/scheduler/server/services/GraphQLMerlinDatabaseService.java
@@ -330,7 +330,7 @@ public record GraphQLMerlinDatabaseService(URI merlinGraphqlURI, String hasuraGr
           .getSpecType()
           .getInputType()
           .getEffectiveArguments(deserializedArguments);
-      final var merlinActivity = new ActivityDirective(
+      final var merlinActivity = new ActivityDirective<?>(
           durationFromPGInterval(start),
           type,
           effectiveArguments,
@@ -432,7 +432,7 @@ public record GraphQLMerlinDatabaseService(URI merlinGraphqlURI, String hasuraGr
       if (actFromInitialPlanOptional.isPresent()) {
         final var actFromInitialPlan = actFromInitialPlanOptional.get();
         //if act was present in initial plan
-        final var activityDirectiveFromSchedulingDirective = new ActivityDirective(
+        final var activityDirectiveFromSchedulingDirective = new ActivityDirective<?>(
             activity.startOffset(),
             activity.type().getName(),
             activity.arguments(),

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinDatabaseService.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/MockMerlinDatabaseService.java
@@ -48,7 +48,7 @@ class MockMerlinDatabaseService implements MerlinDatabaseService.OwnerRole {
 
   private Optional<MissionModelInfo> missionModelInfo = Optional.empty();
   private MerlinPlan initialPlan;
-  Collection<ActivityDirective> updatedPlan;
+  Collection<ActivityDirective<?>> updatedPlan;
   Plan plan;
 
   MockMerlinDatabaseService() {
@@ -58,7 +58,7 @@ class MockMerlinDatabaseService implements MerlinDatabaseService.OwnerRole {
         TimeUtility.fromDOY("2021-005T00:00:00")));
   }
 
-  void setInitialPlan(final Map<ActivityDirectiveId, ActivityDirective> initialActivities) {
+  void setInitialPlan(final Map<ActivityDirectiveId, ActivityDirective<?>> initialActivities) {
     final var newInitialPlan = new MerlinPlan();
     for (final var activity : initialActivities.entrySet()) {
       newInitialPlan.addActivity(activity.getKey(), activity.getValue());
@@ -217,8 +217,8 @@ class MockMerlinDatabaseService implements MerlinDatabaseService.OwnerRole {
   }
 
 
-  private static Collection<ActivityDirective> extractActivityDirectives(final Plan plan, final SchedulerModel schedulerModel) {
-    final var activityDirectives = new ArrayList<ActivityDirective>();
+  private static Collection<ActivityDirective<?>> extractActivityDirectives(final Plan plan, final SchedulerModel schedulerModel) {
+    final var activityDirectives = new ArrayList<ActivityDirective<?>>();
     for (final var activity : plan.getActivities()) {
       final var type = activity.getType();
       final var arguments = new HashMap<>(activity.arguments());
@@ -230,7 +230,7 @@ class MockMerlinDatabaseService implements MerlinDatabaseService.OwnerRole {
               schedulerModel.serializeDuration(activity.duration()));
         }
       }
-      activityDirectives.add(new ActivityDirective(
+      activityDirectives.add(new ActivityDirective<?>(
           activity.startOffset(),
           activity.getType().getName(),
           arguments,

--- a/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingEdslIntegrationTests.java
+++ b/scheduler-worker/src/test/java/gov/nasa/jpl/aerie/scheduler/worker/services/SchedulingEdslIntegrationTests.java
@@ -311,7 +311,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
@@ -356,7 +356,7 @@ public class SchedulingEdslIntegrationTests {
     final var growBananaDuration = Duration.of(1, Duration.HOUR);
     final var results = runScheduler(
         BANANANATION,
-        List.of(new ActivityDirective(
+        List.of(new ActivityDirective<?>(
             Duration.ZERO,
             "GrowBanana",
             Map.of(
@@ -403,14 +403,14 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
                 null,
                 true
             ),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.MINUTE.times(5),
                 "GrowBanana",
                 Map.of(
@@ -453,7 +453,7 @@ public class SchedulingEdslIntegrationTests {
     final var growBananaDuration = Duration.of(1, Duration.HOUR);
     final var results = runScheduler(
         BANANANATION,
-        List.of(new ActivityDirective(
+        List.of(new ActivityDirective<?>(
                     Duration.HOUR,
                     "GrowBanana",
                     Map.of(
@@ -461,7 +461,7 @@ public class SchedulingEdslIntegrationTests {
                         "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
                     null,
                     true),
-                new ActivityDirective(
+                new ActivityDirective<?>(
                     Duration.MINUTE.times(50),
                     "ChangeProducer",
                     Map.of(
@@ -496,14 +496,14 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
                 null,
                 true
             ),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.MINUTE.times(5),
                 "GrowBanana",
                 Map.of(
@@ -541,7 +541,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
@@ -582,7 +582,7 @@ public class SchedulingEdslIntegrationTests {
 
   @Test
   void testCoexistencePartialActWithParameter() {
-    final var expectedSatisfactionAct = new ActivityDirective(
+    final var expectedSatisfactionAct = new ActivityDirective<?>(
         Duration.MINUTE.times(5),
         "GrowBanana",
         Map.of(
@@ -595,14 +595,14 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
                 null,
                 true
             ),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.MINUTE.times(5),
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
@@ -610,7 +610,7 @@ public class SchedulingEdslIntegrationTests {
                 true
             ),
             expectedSatisfactionAct,
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.MINUTE.times(10),
                 "GrowBanana",
                 Map.of(
@@ -669,7 +669,7 @@ public class SchedulingEdslIntegrationTests {
 
   @Test
   void testRecurrenceWithActivityFinder() {
-    final var expectedMatch1 =  new ActivityDirective(
+    final var expectedMatch1 =  new ActivityDirective<?>(
         Duration.of(0, SECONDS),
         "GrowBanana",
         Map.of(
@@ -677,7 +677,7 @@ public class SchedulingEdslIntegrationTests {
             "growingDuration", SerializedValue.of(Duration.of(1, SECONDS).in(Duration.MICROSECONDS))),
         null,
         true);
-    final var expectedMatch2 = new ActivityDirective(
+    final var expectedMatch2 = new ActivityDirective<?>(
         Duration.of(1, Duration.HOUR.times(24)),
         "GrowBanana",
         Map.of(
@@ -691,7 +691,7 @@ public class SchedulingEdslIntegrationTests {
         List.of(
            expectedMatch1,
             expectedMatch2,
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(3, Duration.HOUR.times(24)),
                 "GrowBanana",
                 Map.of(
@@ -732,7 +732,7 @@ public class SchedulingEdslIntegrationTests {
   void testCardinalityGoalWithActivityFinder() {
     final var results = runScheduler(
         BANANANATION,
-        List.of(new ActivityDirective(
+        List.of(new ActivityDirective<?>(
             Duration.of(0, SECONDS),
             "GrowBanana",
             Map.of(
@@ -770,7 +770,7 @@ public class SchedulingEdslIntegrationTests {
     final var growBananaDuration = Duration.of(1, Duration.HOUR);
     final var results = runScheduler(
         BANANANATION,
-        List.of(new ActivityDirective(
+        List.of(new ActivityDirective<?>(
             Duration.ZERO,
             "GrowBanana",
             Map.of(
@@ -817,14 +817,14 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
                 null,
                 true
             ),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.MINUTE,
                 "GrowBanana",
                 Map.of(
@@ -876,7 +876,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "GrowBanana",
                 Map.of(
@@ -925,7 +925,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -978,7 +978,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1032,7 +1032,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1089,7 +1089,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1142,7 +1142,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1193,7 +1193,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
             BANANANATION,
             List.of(
-                    new ActivityDirective(
+                    new ActivityDirective<?>(
                             Duration.of(5, Duration.MINUTES),
                             "GrowBanana",
                             Map.of(
@@ -1253,7 +1253,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1308,7 +1308,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1362,7 +1362,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -1416,7 +1416,7 @@ public class SchedulingEdslIntegrationTests {
     // Between the end of the GrowBanana, and the beginning of the PickBanana, the StateConstraint is satisfied
     final var growBananaDuration = Duration.of(1, Duration.HOUR);
     final var results = runScheduler(BANANANATION, List.of(
-        new ActivityDirective(
+        new ActivityDirective<?>(
             Duration.of(2, HOURS),
             "GrowBanana",
             Map.of(
@@ -1424,7 +1424,7 @@ public class SchedulingEdslIntegrationTests {
                 "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
             null,
             true),
-        new ActivityDirective(
+        new ActivityDirective<?>(
             Duration.of(4, HOURS),
             "PickBanana",
             Map.of("quantity", SerializedValue.of(100)),
@@ -1459,13 +1459,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -1500,13 +1500,13 @@ public class SchedulingEdslIntegrationTests {
     // BiteBanana takes away 1.0
     // The constraint should be satisfied between the two BiteBananaActivities
     final var results = runScheduler(BANANANATION, List.of(
-        new ActivityDirective(
+        new ActivityDirective<?>(
             Duration.of(2, HOURS),
             "BiteBanana",
             Map.of("biteSize", SerializedValue.of(1.0)),
             null,
             true),
-        new ActivityDirective(
+        new ActivityDirective<?>(
             Duration.of(4, HOURS),
             "BiteBanana",
             Map.of("biteSize", SerializedValue.of(1.0)),
@@ -1541,7 +1541,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(1, HOURS),
                 "GrowBanana",
                 Map.of("quantity", SerializedValue.of(3.0),
@@ -1581,13 +1581,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -1626,13 +1626,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(99)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -1659,10 +1659,10 @@ public class SchedulingEdslIntegrationTests {
     assertEquals(Duration.of(4, HOURS), growBanana.startOffset());
   }
 
-  private static List<ActivityDirective> onePickEveryTenMinutes(final Interval interval){
-    final var plan = new ArrayList<ActivityDirective>();
+  private static List<ActivityDirective<?>> onePickEveryTenMinutes(final Interval interval){
+    final var plan = new ArrayList<ActivityDirective<?>>();
     for(var cur = interval.start; cur.shorterThan(interval.end); cur = cur.plus(Duration.of(10, MINUTES))){
-      plan.add(new ActivityDirective(
+      plan.add(new ActivityDirective<?>(
           cur,
           "PickBanana",
           Map.of("quantity", SerializedValue.of(100)),
@@ -1701,13 +1701,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -1746,13 +1746,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -1794,13 +1794,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(100)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -1838,7 +1838,7 @@ public class SchedulingEdslIntegrationTests {
     // ChangeProducer sets producer to "Dole"
     // The PeelBanana should be placed at the same time as the ChangeProducer
     final var results = runScheduler(BANANANATION, List.of(
-        new ActivityDirective(
+        new ActivityDirective<?>(
             Duration.of(2, HOURS),
             "ChangeProducer",
             Map.of(),
@@ -1867,7 +1867,7 @@ public class SchedulingEdslIntegrationTests {
     // ChangeProducer sets producer to "Dole"
     // The PeelBanana should be placed at the same time as the ChangeProducer
     final var results = runScheduler(BANANANATION, List.of(
-        new ActivityDirective(
+        new ActivityDirective<?>(
             Duration.of(2, HOURS),
             "ChangeProducer",
             Map.of("producer", SerializedValue.of("Fyffes")),
@@ -1931,7 +1931,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(1, SECONDS),
                 "GrowBanana",
                 Map.of(
@@ -1939,7 +1939,7 @@ public class SchedulingEdslIntegrationTests {
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, SECONDS),
                 "GrowBanana",
                 Map.of(
@@ -1947,7 +1947,7 @@ public class SchedulingEdslIntegrationTests {
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(3, SECONDS),
                 "GrowBanana",
                 Map.of(
@@ -1955,7 +1955,7 @@ public class SchedulingEdslIntegrationTests {
                     "growingDuration", SerializedValue.of(growBananaDuration.in(Duration.MICROSECONDS))),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(48, HOURS),
                 "PickBanana",
                 Map.of(
@@ -2039,7 +2039,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(24, HOURS).minus(MICROSECONDS),
                 "BiteBanana",
                 Map.of("biteSize", SerializedValue.of(1)),
@@ -2064,9 +2064,9 @@ public class SchedulingEdslIntegrationTests {
     assertEquals(2, results.updatedPlan().size());
   }
 
-  private static Map<String, Collection<ActivityDirective>>
-  partitionByActivityType(final Iterable<ActivityDirective> activities) {
-    final var result = new HashMap<String, Collection<ActivityDirective>>();
+  private static Map<String, Collection<ActivityDirective<?>>>
+  partitionByActivityType(final Iterable<ActivityDirective<?>> activities) {
+    final var result = new HashMap<String, Collection<ActivityDirective<?>>>();
     for (final var activity : activities) {
       result
           .computeIfAbsent(activity.serializedActivity().getTypeName(), key -> new ArrayList<>())
@@ -2075,9 +2075,9 @@ public class SchedulingEdslIntegrationTests {
     return result;
   }
 
-  private static Map<Duration, Collection<ActivityDirective>>
-  partitionByStartTime(final Iterable<ActivityDirective> activities) {
-    final var result = new HashMap<Duration, Collection<ActivityDirective>>();
+  private static Map<Duration, Collection<ActivityDirective<?>>>
+  partitionByStartTime(final Iterable<ActivityDirective<?>> activities) {
+    final var result = new HashMap<Duration, Collection<ActivityDirective<?>>>();
     for (final var activity : activities) {
       result
           .computeIfAbsent(activity.startOffset(), key -> new ArrayList<>())
@@ -2122,7 +2122,7 @@ public class SchedulingEdslIntegrationTests {
 
   private SchedulingRunResults runScheduler(
       final MissionModelDescription desc,
-      final List<ActivityDirective> plannedActivities,
+      final List<ActivityDirective<?>> plannedActivities,
       final Iterable<EdslGoal> goals,
       final PlanningHorizon planningHorizon){
     return runScheduler(desc, plannedActivities, goals, planningHorizon, 30);
@@ -2130,13 +2130,13 @@ public class SchedulingEdslIntegrationTests {
 
   private SchedulingRunResults runScheduler(
       final MissionModelDescription desc,
-      final List<ActivityDirective> plannedActivities,
+      final List<ActivityDirective<?>> plannedActivities,
       final Iterable<EdslGoal> goals,
       final PlanningHorizon planningHorizon,
       final int cachedEngineStoreCapacity
   )
   {
-    final var activities = new HashMap<ActivityDirectiveId, ActivityDirective>();
+    final var activities = new HashMap<ActivityDirectiveId, ActivityDirective<?>>();
     long id = 1;
     for (final var activityDirective : plannedActivities) {
       activities.put(new ActivityDirectiveId(id++), activityDirective);
@@ -2146,7 +2146,7 @@ public class SchedulingEdslIntegrationTests {
 
   private SchedulingRunResults runScheduler(
       final MissionModelDescription desc,
-      final Map<ActivityDirectiveId, ActivityDirective> plannedActivities,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> plannedActivities,
       final Iterable<EdslGoal> goals,
       final PlanningHorizon planningHorizon
   )
@@ -2156,7 +2156,7 @@ public class SchedulingEdslIntegrationTests {
 
   private SchedulingRunResults runScheduler(
       final MissionModelDescription desc,
-      final List<ActivityDirective> plannedActivities,
+      final List<ActivityDirective<?>> plannedActivities,
       final Iterable<EdslGoal> goals,
       final List<SchedulingConditionRecord> globalSchedulingConditions,
       final PlanningHorizon planningHorizon
@@ -2166,13 +2166,13 @@ public class SchedulingEdslIntegrationTests {
 
   private SchedulingRunResults runScheduler(
       final MissionModelDescription desc,
-      final List<ActivityDirective> plannedActivities,
+      final List<ActivityDirective<?>> plannedActivities,
       final Iterable<EdslGoal> goals,
       final List<SchedulingConditionRecord> globalSchedulingConditions,
       final PlanningHorizon planningHorizon,
       final Optional<ExternalProfiles> externalProfiles
   ){
-    final var activities = new HashMap<ActivityDirectiveId, ActivityDirective>();
+    final var activities = new HashMap<ActivityDirectiveId, ActivityDirective<?>>();
     long id = 1;
     for (final var activityDirective : plannedActivities) {
       activities.put(new ActivityDirectiveId(id++), activityDirective);
@@ -2182,7 +2182,7 @@ public class SchedulingEdslIntegrationTests {
 
   private SchedulingRunResults runScheduler(
       final MissionModelDescription desc,
-      final Map<ActivityDirectiveId, ActivityDirective> plannedActivities,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> plannedActivities,
       final Iterable<EdslGoal> goals,
       final List<SchedulingConditionRecord> globalSchedulingConditions,
       final PlanningHorizon planningHorizon,
@@ -2236,9 +2236,9 @@ public class SchedulingEdslIntegrationTests {
 
   record SchedulingRunResults(
       ScheduleResults scheduleResults,
-      Collection<ActivityDirective> updatedPlan,
+      Collection<ActivityDirective<?>> updatedPlan,
       Plan plan,
-      Map<ActivityDirectiveId, ActivityDirective> idToAct) {}
+      Map<ActivityDirectiveId, ActivityDirective<?>> idToAct) {}
 
   static MerlinDatabaseService.MissionModelTypes loadMissionModelTypesFromJar(
       final String jarPath,
@@ -2287,13 +2287,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(1, Duration.MINUTES),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(99)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(15, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -2348,13 +2348,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, Duration.MINUTES),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(99)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, Duration.MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -2400,13 +2400,13 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, HOURS),
                 "PickBanana",
                 Map.of("quantity", SerializedValue.of(99)),
                 null,
                 true),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(4, HOURS),
                 "GrowBanana",
                 Map.of(
@@ -2464,7 +2464,7 @@ public class SchedulingEdslIntegrationTests {
                                                     TimeUtility.fromDOY("2021-200T01:00:00"));
     final var results = runScheduler(BANANANATION,
                  List.of(
-                     new ActivityDirective(
+                     new ActivityDirective<?>(
                          Duration.of(1, HOURS),
                          "parent",
                          Map.of(),
@@ -2494,7 +2494,7 @@ public class SchedulingEdslIntegrationTests {
                                                     TimeUtility.fromDOY("2021-200T01:00:00"));
     final var results = runScheduler(BANANANATION,
                                      List.of(
-                                         new ActivityDirective(
+                                         new ActivityDirective<?>(
                                              Duration.of(1, HOURS),
                                              "parent",
                                              Map.of(),
@@ -2594,7 +2594,7 @@ public class SchedulingEdslIntegrationTests {
   void test_inf_loop(){
     final var results = runScheduler(
         BANANANATION,
-        List.of(new ActivityDirective(
+        List.of(new ActivityDirective<?>(
             Duration.of(23, HOURS),
             "BiteBanana",
             Map.of("biteSize", SerializedValue.of(10)),
@@ -2637,7 +2637,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "DurationParameterActivity",
                 Map.of(
@@ -2645,7 +2645,7 @@ public class SchedulingEdslIntegrationTests {
                 null,
                 true),
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "GrowBanana",
                 Map.of(
@@ -2654,7 +2654,7 @@ public class SchedulingEdslIntegrationTests {
                 new ActivityDirectiveId(1L),
                 false),
             new ActivityDirectiveId(3L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, MINUTES),
                 "ControllableDurationActivity",
                 Map.of(
@@ -2721,7 +2721,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "DurationParameterActivity",
                 Map.of(
@@ -2729,7 +2729,7 @@ public class SchedulingEdslIntegrationTests {
                 null,
                 true),
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "GrowBanana",
                 Map.of(
@@ -2738,7 +2738,7 @@ public class SchedulingEdslIntegrationTests {
                 new ActivityDirectiveId(1L),
                 false),
             new ActivityDirectiveId(3L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, MINUTES),
                 "ControllableDurationActivity",
                 Map.of(
@@ -2805,7 +2805,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 tenMinutes,
                 "DurationParameterActivity",
                 Map.of(
@@ -2813,7 +2813,7 @@ public class SchedulingEdslIntegrationTests {
                 null,
                 true),
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(-5, MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -2880,7 +2880,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "DurationParameterActivity",
                 Map.of(
@@ -2888,7 +2888,7 @@ public class SchedulingEdslIntegrationTests {
                 null,
                 true),
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 tenMinutes,
                 "PickBanana",
                 Map.of(
@@ -2958,7 +2958,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 tenMinutes,
                 "GrowBanana",
                 Map.of(
@@ -3028,7 +3028,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 tenMinutes,
                 "GrowBanana",
                 Map.of(
@@ -3091,7 +3091,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "DurationParameterActivity",
                 Map.of(
@@ -3099,7 +3099,7 @@ public class SchedulingEdslIntegrationTests {
                 null,
                 true),
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 tenMinutes,
                 "GrowBanana",
                 Map.of(
@@ -3161,7 +3161,7 @@ public class SchedulingEdslIntegrationTests {
         Map.of(
             // Activity Before Plan Start
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(-10, MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -3171,7 +3171,7 @@ public class SchedulingEdslIntegrationTests {
                 true),
             // Activity Anchored to run after Plan End
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(10, MINUTES),
                 "GrowBanana",
                 Map.of(
@@ -3237,7 +3237,7 @@ public class SchedulingEdslIntegrationTests {
           BANANANATION,
           Map.of(
               new ActivityDirectiveId(1L),
-              new ActivityDirective(
+              new ActivityDirective<?>(
                   Duration.ZERO,
                   "GrowBanana",
                   Map.of(
@@ -3297,7 +3297,7 @@ public class SchedulingEdslIntegrationTests {
     final var results = runScheduler(
         FOO,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(5, MINUTES),
                 "ZeroDurationUncontrollableActivity",
                 Map.of(),
@@ -3355,14 +3355,14 @@ public class SchedulingEdslIntegrationTests {
     runScheduler(
         BANANANATION,
         List.of(
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "BananaNap",
                 Map.of(),
                 null,
                 true
             ),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.SECOND,
                 "DownloadBanana",
                 Map.of("connection", SerializedValue.of("DietaryFiberOptic")),
@@ -3384,7 +3384,7 @@ public class SchedulingEdslIntegrationTests {
         BANANANATION,
         Map.of(
             new ActivityDirectiveId(1L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.ZERO,
                 "GrowBanana",
                 Map.of(
@@ -3393,7 +3393,7 @@ public class SchedulingEdslIntegrationTests {
                 null,
                 true),
             new ActivityDirectiveId(2L),
-            new ActivityDirective(
+            new ActivityDirective<?>(
                 Duration.of(2, activityDuration),
                 "GrowBanana",
                 Map.of(

--- a/type-utils/src/main/java/gov/nasa/jpl/aerie/types/ActivityDirective.java
+++ b/type-utils/src/main/java/gov/nasa/jpl/aerie/types/ActivityDirective.java
@@ -4,14 +4,30 @@ import gov.nasa.jpl.aerie.merlin.protocol.types.Duration;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
-public record ActivityDirective(
+public record ActivityDirective<T>(
     Duration startOffset,
-    SerializedActivity serializedActivity,
+    T thing,
+    Supplier<SerializedActivity> thunk,
     ActivityDirectiveId anchorId, // anchorId can be null
     boolean anchoredToStart,
     String name
 ) {
+  private ActivityDirective(
+      final Duration startOffset,
+      final SerializedActivity serializedActivity,
+      final ActivityDirectiveId anchorId,
+      final boolean anchoredToStart,
+      final String name) {
+    this(startOffset,
+         (T) serializedActivity,
+         () -> serializedActivity,
+         anchorId,
+         anchoredToStart,
+         name);
+  }
+
   public ActivityDirective(
       final Duration startOffset,
       final String type,
@@ -24,5 +40,9 @@ public record ActivityDirective(
          anchorId,
          anchoredToStart,
          name);
+  }
+
+  public SerializedActivity serializedActivity() {
+    return this.thunk.get();
   }
 }

--- a/type-utils/src/main/java/gov/nasa/jpl/aerie/types/Plan.java
+++ b/type-utils/src/main/java/gov/nasa/jpl/aerie/types/Plan.java
@@ -17,7 +17,7 @@ public final class Plan {
   private final MissionModelId missionModelId;
   private final Timestamp startTimestamp;
   private final Timestamp endTimestamp;
-  private final Map<ActivityDirectiveId, ActivityDirective> activityDirectives;
+  private final Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives;
   private final Map<String, SerializedValue> configuration;
 
   // Simulation start and end times can be freely updated
@@ -29,7 +29,7 @@ public final class Plan {
       final MissionModelId missionModelId,
       final Timestamp startTimestamp,
       final Timestamp endTimestamp,
-      final Map<ActivityDirectiveId, ActivityDirective> activityDirectives
+      final Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives
   ) {
     this(
         name,
@@ -46,7 +46,7 @@ public final class Plan {
       String name,
       Timestamp startTimestamp,
       Timestamp endTimestamp,
-      Map<ActivityDirectiveId, ActivityDirective> activityDirectives,
+      Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives,
       Map<String, SerializedValue> simulationConfig
   ) {
     this(
@@ -65,7 +65,7 @@ public final class Plan {
       final MissionModelId missionModelId,
       final Timestamp startTimestamp,
       final Timestamp endTimestamp,
-      final Map<ActivityDirectiveId, ActivityDirective> activityDirectives,
+      final Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives,
       final Map<String, SerializedValue> configuration,
       final Timestamp simulationStartTimestamp,
       final Timestamp simulationEndTimestamp
@@ -116,7 +116,7 @@ public final class Plan {
   /**
    * Get the map of grounded activity directives in this plan.
    */
-  public Map<ActivityDirectiveId, ActivityDirective> activityDirectives() {return activityDirectives;}
+  public Map<ActivityDirectiveId, ActivityDirective<?>> activityDirectives() {return activityDirectives;}
 
   /**
    * Get the requested simulation configuration.


### PR DESCRIPTION
This PR allows a user to store an opaque generic value inside of an activity directive. The purpose here is to allow a scheduler to pack arbitrary metadata into a directive without making that an explicit part of the class.