### PR TITLE
Update merlin and scheduler worker containers to use debian bookworm

### DIFF
--- a/merlin-server/Dockerfile
+++ b/merlin-server/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir -p /usr/src/app/extracted \
     && tar --strip-components 1 -xf /usr/src/app/server.tar -C /usr/src/app/extracted
 
-FROM node:24.18.0-bullseye-slim AS dsl-node-builder
+FROM node:24.18.0-bookworm-slim AS dsl-node-builder
 
 WORKDIR /opt/constraints-dsl-compiler
 
@@ -22,7 +22,7 @@ RUN npm ci --ignore-scripts \
 COPY constraints-dsl-compiler/ ./
 RUN npm run build && npm prune --omit=dev
 
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jre-noble
 
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 COPY --from=dsl-node-builder /usr/local/bin/node /usr/local/bin/node

--- a/scheduler-worker/Dockerfile
+++ b/scheduler-worker/Dockerfile
@@ -4,7 +4,7 @@ COPY build/distributions/*.tar /usr/src/app/server.tar
 RUN mkdir -p /usr/src/app/extracted \
     && tar --strip-components 1 -xf /usr/src/app/server.tar -C /usr/src/app/extracted
 
-FROM node:24.18.0-bullseye-slim AS dsl-node-builder
+FROM node:24.18.0-bookworm-slim AS dsl-node-builder
 
 WORKDIR /opt/scheduling-dsl-compiler
 
@@ -22,7 +22,7 @@ RUN npm ci --ignore-scripts \
 COPY scheduling-dsl-compiler/ ./
 RUN npm run build && npm prune --omit=dev
 
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jre-noble
 
 COPY --from=extractor /usr/src/app/extracted /usr/src/app
 COPY --from=dsl-node-builder /usr/local/bin/node /usr/local/bin/node


### PR DESCRIPTION
Updates the Merlin Server Docker images from Debian Bullseye to Bookworm and from Ubuntu Jammy to Noble.

Debian 11/Bullseye reached end-of-life on August 31, 2026, and its security repository metadata has now expired, causing `apt-get update` to fail during the Merlin Server image build. Debian recommends upgrading Bullseye systems to Bookworm. [Debian 11 LTS end-of-life announcement](https://www.debian.org/News/2026/20260831) [Node Bookworm image tags](https://hub.docker.com/_/node/tags?name=-bookworm-slim&page=1)

The runtime image is also updated from Jammy to Noble because the Node build stage compiles native `isolated-vm` artifacts that are copied into the final Java runtime image. Bookworm uses a newer `glibc` than Jammy, so keeping Jammy as the runtime can introduce native-library compatibility issues. Noble provides a newer `glibc` and keeps the runtime environment compatible with artifacts built on Bookworm. [Ubuntu Jammy libc6 (glibc 2.35)](https://packages.ubuntu.com/jammy/libc6?utm_source=chatgpt.com) [Ubuntu Noble libc6 (glibc 2.39)](https://packages.ubuntu.com/noble/libc6?utm_source=chatgpt.com)